### PR TITLE
revise copy to fix typos and improve readability

### DIFF
--- a/index.html
+++ b/index.html
@@ -382,7 +382,7 @@ We can't wait to meet you!</p>
                 <li>Enhanced privacy</li>
                 <li>Payment integration</li>
 		</ul>
-		<p>Read about these and more on <a href="https://blog.decred.org" target="_blank">our blog</a> and welcome to Decred; the future of digital currency.</p>
+		<p>Read about these and more on <a href="https://blog.decred.org" target="_blank">our blog</a> and welcome to Decred: the future of digital currency.</p>
 		</div>
                 <a class="borderradius4 buttoncontinue dropshadow font14 fontsemibold transition w-button" href="#">Continue</a>
                 <a class="borderradius4 buttonback dropshadow font14 fontsemibold transition w-button" href="#">Back</a>

--- a/index.html
+++ b/index.html
@@ -300,7 +300,7 @@
             <div class="content transitionmodest w-clearfix">
               <div class="media"><img src="./content/images/07_pos.png" alt="Proof-of-Stake"></div>
               <div class="info w-clearfix">
-                <div class="text"><p>Contrary to PoW, <a href="https://docs.decred.org/mining/proof-of-work/" title="_blank">Proof-of-Stake mining (PoS)</a> requires little computing resources. Decred funds are used to purchase voting tickets on the network. Every block, five tickets from the pool of live tickets are chosen at random to vote on the validity of the previous block. </p>
+                <div class="text"><p>Unlike PoW, <a href="https://docs.decred.org/mining/proof-of-work/" title="_blank">Proof-of-Stake mining (PoS)</a> requires little computing resources. Decred funds are used to purchase voting tickets on the network. Every block, five tickets from the pool of live tickets are chosen at random to vote on the validity of the previous block. </p>
 		<p>PoS adds an extra layer of decentralization to Decred and allows users to vote on suggested network changes. <a href="https://docs.decred.org/mining/proof-of-stake/#sign-up-for-a-stake-pool" title="_blank">Pools are also available for PoS</a> to ensure your tickets are ready to vote whenever they're called.</p>
 		</div>
                 <a class="borderradius4 buttoncontinue dropshadow font14 fontsemibold transition w-button" href="#">Continue</a>

--- a/index.html
+++ b/index.html
@@ -161,7 +161,7 @@
               <div class="info w-clearfix">
                 <div class="text">
 		<p>Decred is a multi-platform digital currency with support for Windows, Mac, and Linux. Easy-to-use wallet apps enable sending, receiving, and mining Decred with just a few clicks.</p>
-		<p>For those who like to tinker, Decred provides a full suite of command line tools allowing the customization of the Decred experience.</p>
+		<p>For those who like to tinker, Decred provides a full suite of command line tools allowing customization of the Decred experience.</p>
                 </div>
                 <a class="borderradius4 buttoncontinue dropshadow font14 fontsemibold transition w-button" href="#">Continue</a>
                 <a class="borderradius4 buttonback dropshadow font14 fontsemibold transition w-button" href="#">Back</a>

--- a/index.html
+++ b/index.html
@@ -208,7 +208,7 @@
             <div class="content transitionmodest w-clearfix">
               <div class="media"><img src="./content/images/03_wallets.png" alt="Wallets"></div>
               <div class="info w-clearfix">
-                <div class="text"><p>The Web Wallet is the easiest way to get started with Decred. All users can access online it via <a href="https://wallet.decred.org" target="_blank">wallet.decred.org</a>, without needing to download anything.
+                <div class="text"><p>The Web Wallet is the easiest way to get started with Decred. All users can access it online via <a href="https://wallet.decred.org" target="_blank">wallet.decred.org</a>, without needing to download anything.
 </p>
 		<p>For Windows users, Paymetheus wallet (<a href="https://github.com/decred/decred-binaries/releases/download/v0.8.2/decred_0.8.2-beta_x64.msi">64-bit ↓</a>, <a href="https://github.com/decred/decred-binaries/releases/download/v0.8.2/decred_0.8.2-beta_x86.msi">32-bit ↓</a>) will help you get online in just a few minutes.</p>
 		<p>For Mac and Linux users, Decrediton wallet is available as a preview release (<a href="https://github.com/decred/decred-binaries/releases/download/v0.8.2/decrediton-0.8.2.dmg">Mac ↓</a>, <a href="https://github.com/decred/decred-binaries/releases/download/v0.8.2/decrediton-0.8.2.tar.gz">Linux ↓</a>) but is not feature complete. For general usage, it is recommended to use our command line tools for the time being. You can get up and running with <a href="https://docs.decred.org/getting-started/install-guide/" title="_blank">complete step-by-step instructions</a>.</p></div>

--- a/index.html
+++ b/index.html
@@ -232,7 +232,7 @@
             <div class="content transitionmodest w-clearfix">
               <div class="media"><img src="./content/images/04_send-receive.png" alt="Send/Receive"></div>
               <div class="info w-clearfix">
-                <div class="text"><p>An address is the only thing needed to send or receive funds. It can be easily generated from the wallet. Decred addresses always <a href="https://docs.decred.org/faq/wallets-and-seeds/#9-what-are-the-different-types-of-addresses" target="_blank">begin with D and contain 26-36 alphanumeric characters</a>.</p>
+                <div class="text"><p>An address is the only thing needed to send or receive funds. It can be easily generated from any Decred wallet. Decred addresses always <a href="https://docs.decred.org/faq/wallets-and-seeds/#9-what-are-the-different-types-of-addresses" target="_blank">begin with D and contain 26-36 alphanumeric characters</a>.</p>
 		<p>After a transaction is made, funds will usually clear in about 5 minutes. There is a small fee to help with the upkeep of the network. This fee is in addition to the transaction amount. E.g. a transfer of 100DCR would incur a fee of about 0.06DCR.</p>
 		<p>The <a href="https://mainnet.decred.org" target="_blank">Main Network Block Explorer</a> allows users to search all the blocks and transactions in the Decred blockchain.</p></div>
                 <a class="borderradius4 buttoncontinue dropshadow font14 fontsemibold transition w-button" href="#">Continue</a>


### PR DESCRIPTION
commit | reasoning
--- | ---
[fix typo: "online it"](https://github.com/decred/dcrweb/commit/023194159206ac97ea7fa05b959ffb0f6ccf1922) | words got reversed
[fix copy: remove superfluous "the"](https://github.com/decred/dcrweb/commit/cc9cea24821bdf8213530fa319a7579d0f821e83) | having two instances of "the" costs an extra word with limited to no upside
[specify "any Decred wallet"](https://github.com/decred/dcrweb/commit/fccb19f17c26893f3ee1b7e20ef3e6756f5faf8b) | was "the wallet" - but there is more than one wallet
[shorten copy: "Contrary to"](https://github.com/decred/dcrweb/commit/f9508cb767fbf2c6c13f44de6131c3824b48fa78) | "Unlike" saves a word and improves readability
[fix typo: semicolon](https://github.com/decred/dcrweb/commit/da6d2e673175c294dafe898d97e93717cb1f29ee) | a colon is needed for effect here as opposed to a semicolon