### PR TITLE
Remove links to old wiki

### DIFF
--- a/brand/index.html
+++ b/brand/index.html
@@ -133,7 +133,6 @@
           <div class="footerrowscolumn1 w-col w-col-2">
             <a class="footerblocklink transition" href="https://docs.decred.org/research/overview/" target="_blank">Technical Brief</a>
             <a class="footerblocklink transition" href="https://docs.decred.org/" target="_blank">Documentation</a>
-            <a class="footerblocklink transition" href="https://wiki.decred.org/" target="_blank">Wiki</a>
             <a class="footerblocklink transition" href="../">← Main Website</a>
           </div>
           <div class="footerrowscolumn1 w-col w-col-2">

--- a/index.html
+++ b/index.html
@@ -134,7 +134,7 @@
               <h1 class="colorblue font38 fontsemibold lineheigh45 margin30">Community And Principles</h1>
               <div class="colorgray font16 margin30">The project is bound by the Decred Constitution, so users can know what to expect: a finite number of coins, decentralized governance and a place to share their views. &nbsp;Decred's community plays an important role in making decisions, both informally via the forum and formally via the blockchain.</div>
               <div class="overviewtextbottom">
-                <a class="colorblue font14 fontsemibold overviewtextbottomlink transition" href="https://wiki.decred.org/Decred_Constitution" target="_blank">Read the Decred Constitution →</a>
+                <a class="colorblue font14 fontsemibold overviewtextbottomlink transition" href="https://docs.decred.org/getting-started/constitution/" target="_blank">Read the Decred Constitution →</a>
               </div>
             </div>
           </div>
@@ -402,7 +402,6 @@ We can't wait to meet you!</p>
           <div class="footerrowscolumn1 w-col w-col-2 w-col-small-small-stack">
             <a class="footerblocklink transition" href="https://docs.decred.org/research/overview/" target="_blank">Technical Brief</a>
             <a class="footerblocklink transition" href="https://docs.decred.org/" target="_blank">Documentation</a>
-            <a class="footerblocklink transition" href="https://wiki.decred.org/" target="_blank">Wiki</a>
             <a class="footerblocklink transition" href="./brand/" target="_blank">Logo and Branding</a>
           </div>
           <div class="footerrowscolumn1 w-col w-col-2 w-col-small-small-stack">


### PR DESCRIPTION
Replace the link to the Decred Constitution on wiki with link to the
same document on the decred docs site.

Closes #50 