### PR TITLE
Stakepool Modal open URL

### DIFF
--- a/content/js/main.js
+++ b/content/js/main.js
@@ -555,5 +555,8 @@ $(document).ready(function() {
 	    	displayStakepools($(this));
 	}, time * 3));
 
+  if(window.location.href.indexOf('#modalOpen') != -1) {
+	$('#modalOpen').click();
+  }
 
 });


### PR DESCRIPTION
This small js-addition enables us to have direct-links to an allready opened Modal-Stakepool Window:
http://decred.org//index.html#modalOpen

closes #57 