### PR TITLE
don't list pools that are stuck on API v1

### DIFF
--- a/api/index.php
+++ b/api/index.php
@@ -142,7 +142,12 @@ case "gsd":
     getStakepoolData($spdata);
     $allpooldata = array();
     foreach (array_keys($spdata) as $i) {
-        $allpooldata[$i] = apcu_fetch("spcache-{$i}");
+        $pooldata = apcu_fetch("spcache-{$i}");
+        if (!in_array(2, $pooldata["APIVersionsSupported"])) {
+            // don't output pools that are stuck on API v1
+            continue;
+        }
+        $allpooldata[$i] = $pooldata;
     }
     array_shuffle($allpooldata);
     print json_encode($allpooldata, JSON_NUMERIC_CHECK|JSON_PRETTY_PRINT);

--- a/api/index.php
+++ b/api/index.php
@@ -3,6 +3,8 @@
 $GLOBALS["clearcache"] = 0;
 $GLOBALS["debug"] = 0;
 
+define("STAKEPOOL_API_CURRENT_VERSION", 2);
+
 if ($GLOBALS["clearcache"]) {
     apcu_clear_cache();
 }
@@ -143,7 +145,7 @@ case "gsd":
     $allpooldata = array();
     foreach (array_keys($spdata) as $i) {
         $pooldata = apcu_fetch("spcache-{$i}");
-        if (!in_array(2, $pooldata["APIVersionsSupported"])) {
+        if (!in_array(STAKEPOOL_API_CURRENT_VERSION, $pooldata["APIVersionsSupported"])) {
             // don't output pools that are stuck on API v1
             continue;
         }
@@ -474,13 +476,13 @@ function getStakepoolData($spdata) {
             }
 
             // first try API v2
-            list ($timedOut, $stats) = getStakepoolStatsAPI($cachedData["URL"], $timeOut, $fields, 2);
+            list ($timedOut, $stats) = getStakepoolStatsAPI($cachedData["URL"], $timeOut, $fields, STAKEPOOL_API_CURRENT_VERSION);
 
             // if API v2 worked then note that
             if (!empty($stats)) {
                 debugLog("got stats via API from {$cachedData["URL"]}");
                 $cachedData["APIEnabled"] = true;
-                $cachedData["APIVersionsSupported"] = array(1, 2);
+                $cachedData["APIVersionsSupported"] = array(1, STAKEPOOL_API_CURRENT_VERSION);
             }
 
             // try API v1 if v2 failed but only if we didn't timeout

--- a/api/index.php
+++ b/api/index.php
@@ -475,17 +475,17 @@ function getStakepoolData($spdata) {
                 $cachedData["Network"] = $spdata[$i]["Network"];
             }
 
-            // first try API v2
+            // first try current API version
             list ($timedOut, $stats) = getStakepoolStatsAPI($cachedData["URL"], $timeOut, $fields, STAKEPOOL_API_CURRENT_VERSION);
 
-            // if API v2 worked then note that
+            // if current API version worked then note that
             if (!empty($stats)) {
                 debugLog("got stats via API from {$cachedData["URL"]}");
                 $cachedData["APIEnabled"] = true;
                 $cachedData["APIVersionsSupported"] = array(1, STAKEPOOL_API_CURRENT_VERSION);
             }
 
-            // try API v1 if v2 failed but only if we didn't timeout
+            // fall back to old API version but only if we didn't timeout
             if (empty($stats)) {
                 if (!$timedOut) {
                     list ($timedOut, $stats) = getStakepoolStatsAPI($cachedData["URL"], $timeOut, $fields, 1);


### PR DESCRIPTION
One pool hasn't upgraded and since they can't respect user's voting preferences, it's best to just hide them from the list data.

If they ever upgrade, they will be listed again.