### PR TITLE
Removed unnecessary link in download counters (#93)

### DIFF
--- a/brand/index.html
+++ b/brand/index.html
@@ -145,7 +145,7 @@
             </div>
             <div class="footerblockstatsrow w-clearfix">
               <!-- this is a placeholder that gets updated with a more accurate value via javascript -->
-              <a class="backgroundwashedblue borderradius4 dropshadow footerblockstatslink" id="footerDownloads" href="#">100k total</a>
+              <a class="backgroundwashedblue borderradius4 dropshadow footerblockstatslink" id="footerDownloads">100k total</a>
               <div class="footerblockstatsname">downloads</div>
             </div>
           </div>

--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@
           <div class="developmentrow">
             <div class="developmentrowname">Downloads</div>
             <!-- this is a placeholder that gets updated with a more accurate value via javascript -->
-            <a class="backgroundwashedblue borderradius4 developmentrownum fontsemibold" href="#" id="statisticsDownloads">100k total</a>
+            <a class="backgroundwashedblue borderradius4 developmentrownum fontsemibold" id="statisticsDownloads">100k total</a>
           </div>
         </div>
       </div>
@@ -424,7 +424,7 @@ We can't wait to meet you!</p>
             </div>
             <div class="footerblockstatsrow w-clearfix">
               <!-- this is a placeholder that gets updated with a more accurate value via javascript -->
-              <a class="backgroundwashedblue borderradius4 dropshadow footerblockstatslink" href="#" id="footerDownloads">100k total</a>
+              <a class="backgroundwashedblue borderradius4 dropshadow footerblockstatslink" id="footerDownloads">100k total</a>
               <div class="footerblockstatsname">downloads</div>
             </div>
           </div>


### PR DESCRIPTION
Fixes #93 
The  unnecessary link was removed from the download counters in the 'Statistics' section, home page footer, and /brand page footer.