### PR TITLE
update links to point to 1.1.0

### DIFF
--- a/src/brand/index.html
+++ b/src/brand/index.html
@@ -162,7 +162,7 @@
           </div>
           <div class="footerrowscolumn1 w-col w-col-2">
             <div class="footerblockstatsrow w-clearfix">
-              <a class="backgroundturquoise borderradius4 dropshadow footerblockstatslink" id="footerRelease" href="https://github.com/decred/decred-release/releases/tag/v1.0.8" target="_blank">v1.0.8</a>
+              <a class="backgroundturquoise borderradius4 dropshadow footerblockstatslink" id="footerRelease" href="https://github.com/decred/decred-release/releases/tag/v1.1.0" target="_blank">v1.1.0</a>
               <div class="footerblockstatsname">stable</div>
             </div>
             <div class="footerblockstatsrow w-clearfix">

--- a/src/downloads/index.html
+++ b/src/downloads/index.html
@@ -88,18 +88,18 @@
           <div class="paymetheus section-card-title-download-page" translate>Paymetheus</div>
           <div class="section-card-description-download" translate>GUI wallet for Windows</div>
           <div class="section-card-download-links-download-page w-clearfix">
-            <a class="section-card-link-download-page" href="https://github.com/decred/decred-binaries/releases/download/v1.0.8/decred_1.0.8-release_x64.msi" target="_blank"><span translate>Win 64-bit</span> ↓</a>
+            <a class="section-card-link-download-page" href="https://github.com/decred/decred-binaries/releases/download/v1.1.0/decred_1.1.0-release_x64.msi" target="_blank"><span translate>Win 64-bit</span> ↓</a>
             <div class="seperator"></div>
-            <a class="section-card-link-download-page" href="https://github.com/decred/decred-binaries/releases/download/v1.0.8/decred_1.0.8-release_x86.msi" target="_blank"><span translate>Win 32-bit</span> ↓</a>
+            <a class="section-card-link-download-page" href="https://github.com/decred/decred-binaries/releases/download/v1.1.0/decred_1.1.0-release_x86.msi" target="_blank"><span translate>Win 32-bit</span> ↓</a>
           </div>
         </div>
         <div class="section-card-download-page" id="decrediton">
           <div class="decrediton section-card-title-download-page" translate>Decrediton</div>
           <div class="section-card-description-download" translate>GUI wallet for macOS and Linux</div>
           <div class="section-card-download-links-download-page w-clearfix">
-            <a class="section-card-link-download-page" href="https://github.com/decred/decred-binaries/releases/download/v1.0.8/decrediton-1.0.8.dmg" target="_blank"><span translate>macOS</span></a>
+            <a class="section-card-link-download-page" href="https://github.com/decred/decred-binaries/releases/download/v1.1.0/decrediton-1.1.0.dmg" target="_blank"><span translate>macOS</span></a>
             <div class="seperator"></div>
-            <a class="section-card-link-download-page" href="https://github.com/decred/decred-binaries/releases/download/v1.0.8/decrediton-1.0.8.tar.gz" target="_blank"><span translate>Linux 64-bit</span> ↓</a>
+            <a class="section-card-link-download-page" href="https://github.com/decred/decred-binaries/releases/download/v1.1.0/decrediton-1.1.0.tar.gz" target="_blank"><span translate>Linux 64-bit</span> ↓</a>
           </div>
         </div>
         <div class="section-card-download-page" id="webwallet">
@@ -113,7 +113,7 @@
           <div class="commandline section-card-title-download-page" translate>Command Line Suite</div>
           <div class="section-card-description-download" translate>A cross-platform, automatic installer/updater for the command-line applications.</div>
           <div class="section-card-download-links-download-page w-clearfix">
-            <a class="section-card-link-download-page" href="https://github.com/decred/decred-release/releases/tag/v1.0.8" target="_blank"><span translate>View on GitHub</span> →</a>
+            <a class="section-card-link-download-page" href="https://github.com/decred/decred-release/releases/tag/v1.1.0" target="_blank"><span translate>View on GitHub</span> →</a>
           </div>
         </div>
       </div>

--- a/src/index.html
+++ b/src/index.html
@@ -71,11 +71,11 @@
       <div class="download-buttons">
         <div class="download-buttons-inner">
           <a class="button download-wallet w-button alldl" href="downloads/" ><span translate>Download Wallet</span><span class="button-description" translate>For Your Computer</span></a>
-          <a class="button download-wallet w-button macdl" href="https://github.com/decred/decred-binaries/releases/download/v1.0.8/decrediton-1.0.8.dmg"><span translate>Download Wallet</span><span class="button-description" translate>Decrediton For macOS</span></a>
-          <a class="button download-wallet w-button linuxdl" href="https://github.com/decred/decred-binaries/releases/download/v1.0.8/decrediton-1.0.8.tar.gz" ><span translate>Download Wallet</span><span class="button-description" translate>Decrediton For Linux</span></a>
-          <a class="button download-wallet w-button win32dl" href="https://github.com/decred/decred-binaries/releases/download/v1.0.8/decred_1.0.8-release_x86.msi" ><span translate>Download Wallet</span><span class="button-description" translate>Paymetheus For Windows 32bit</span></a>
-          <a class="button download-wallet w-button win64dl" href="https://github.com/decred/decred-binaries/releases/download/v1.0.8/decred_1.0.8-release_x64.msi" ><span translate>Download Wallet</span><span class="button-description" translate>Paymetheus For Windows 64bit</span></a>
-          <a class="button download-wallet w-button windl" href="https://github.com/decred/decred-binaries/releases/download/v1.0.8/decred_1.0.8-release_x64.msi" ><span translate>Download Wallet</span><span class="button-description" translate>Paymetheus For Windows</span></a>
+          <a class="button download-wallet w-button macdl" href="https://github.com/decred/decred-binaries/releases/download/v1.1.0/decrediton-1.1.0.dmg"><span translate>Download Wallet</span><span class="button-description" translate>Decrediton For macOS</span></a>
+          <a class="button download-wallet w-button linuxdl" href="https://github.com/decred/decred-binaries/releases/download/v1.1.0/decrediton-1.1.0.tar.gz" ><span translate>Download Wallet</span><span class="button-description" translate>Decrediton For Linux</span></a>
+          <a class="button download-wallet w-button win32dl" href="https://github.com/decred/decred-binaries/releases/download/v1.1.0/decred_1.1.0-release_x86.msi" ><span translate>Download Wallet</span><span class="button-description" translate>Paymetheus For Windows 32bit</span></a>
+          <a class="button download-wallet w-button win64dl" href="https://github.com/decred/decred-binaries/releases/download/v1.1.0/decred_1.1.0-release_x64.msi" ><span translate>Download Wallet</span><span class="button-description" translate>Paymetheus For Windows 64bit</span></a>
+          <a class="button download-wallet w-button windl" href="https://github.com/decred/decred-binaries/releases/download/v1.1.0/decred_1.1.0-release_x64.msi" ><span translate>Download Wallet</span><span class="button-description" translate>Paymetheus For Windows</span></a>
           <a class="button getting-started w-button" href="#guide"><span translate>Getting Started</span><br><span class="button-description"><span translate>The quick tour</span></span></a>
         </div>
         <a class="all-downloads button w-button" href="downloads/"><span translate>All Downloads  →</span></a>
@@ -103,7 +103,7 @@
           <h2 class="font22 fontregular h2 margin20"><span class="fontbold"></span><span translate>Development</span></h2>
           <div class="developmentrow">
             <div class="developmentrowname" translate>Stable Version</div>
-            <a class="backgroundturquoise borderradius4 developmentrownum fontsemibold" id="statisticsRelease" href="https://github.com/decred/decred-release/releases/tag/v1.0.8" target="_blank">v1.0.8</a>
+            <a class="backgroundturquoise borderradius4 developmentrownum fontsemibold" id="statisticsRelease" href="https://github.com/decred/decred-release/releases/tag/v1.1.0" target="_blank">v1.1.0</a>
           </div>
           <div class="developmentrow">
             <div class="developmentrowname" translate>Downloads</div>
@@ -446,7 +446,7 @@ We can't wait to meet you!</p>
           </div>
           <div class="footerblockstats footerrowscolumn1 w-clearfix w-col w-col-2 w-col-small-small-stack">
             <div class="footerblockstatsrow w-clearfix">
-              <a class="backgroundturquoise borderradius4 dropshadow footerblockstatslink" id="footerRelease" href="https://github.com/decred/decred-release/releases/tag/v1.0.8" target="_blank">v1.0.8</a>
+              <a class="backgroundturquoise borderradius4 dropshadow footerblockstatslink" id="footerRelease" href="https://github.com/decred/decred-release/releases/tag/v1.1.0" target="_blank">v1.1.0</a>
               <div class="footerblockstatsname" translate>stable</div>
             </div>
             <div class="footerblockstatsrow w-clearfix">


### PR DESCRIPTION
Does not include link(s) to Decrediton for Windows which is a WIP.  Issue #126 was opened to track that.