### PR TITLE
Fix Windows Decrediton link

### DIFF
--- a/src/downloads/index.html
+++ b/src/downloads/index.html
@@ -97,7 +97,7 @@
           <div class="decrediton section-card-title-download-page" translate>Decrediton</div>
           <div class="section-card-description-download" translate>GUI wallet for Windows, macOS and Linux</div>
           <div class="section-card-download-links-download-page w-clearfix">
-            <a class="section-card-link-download-page" href="https://github.com/decred/decred-binaries/releases/download/v1.1.0/decrediton-1.1.0.exe" target="_blank"><span translate>Windows</span></a>
+            <a class="section-card-link-download-page" href="https://github.com/decred/decred-binaries/releases/download/v1.1.0/decrediton-v1.1.0.exe" target="_blank"><span translate>Windows</span></a>
             <div class="seperator"></div>
             <a class="section-card-link-download-page" href="https://github.com/decred/decred-binaries/releases/download/v1.1.0/decrediton-1.1.0.dmg" target="_blank"><span translate>macOS</span></a>
             <div class="seperator"></div>


### PR DESCRIPTION
Windows release uses a different naming scheme with a "v" in front of the version number.