### PR TITLE
Reorder Decrediton wallet download links (#170)

### DIFF
--- a/src/downloads/index.html
+++ b/src/downloads/index.html
@@ -129,9 +129,9 @@
               <div class="section-card-download-page" id="decrediton">
                   <div class="decrediton section-card-title-download-page" translate>Decrediton</div>
                   <div class="section-card-description-download" translate>Graphic UI wallet for Windows, macOS and Linux.</div>
-                  <div class="section-card-download-links-download-page w-clearfix"><a target="_blank" href="https://github.com/decred/decred-binaries/releases/download/v1.1.1/decrediton-1.1.1.dmg" class="section-card-link-download-page" translate>macOS ↓</a>
+                  <div class="section-card-download-links-download-page w-clearfix"><a target="_blank" href="https://github.com/decred/decred-binaries/releases/download/v1.1.1/decrediton-1.1.1.exe" class="section-card-link-download-page" translate>Windows ↓</a>                    
+                    <div class="seperator"></div><a target="_blank" href="https://github.com/decred/decred-binaries/releases/download/v1.1.1/decrediton-1.1.1.dmg" class="section-card-link-download-page" translate>macOS ↓</a>
                     <div class="seperator"></div><a target="_blank" href="https://github.com/decred/decred-binaries/releases/download/v1.1.1/decrediton-1.1.1.tar.gz" class="section-card-link-download-page" translate>Linux 64-bit ↓</a>
-                    <div class="seperator"></div><a target="_blank" href="https://github.com/decred/decred-binaries/releases/download/v1.1.1/decrediton-1.1.1.exe" class="section-card-link-download-page" translate>Windows ↓</a>
                   </div>
                 </div>
               <div class="section-card-download-page" id="paymetheus">


### PR DESCRIPTION
Order decrediton download links from left to right in the order that they are most often downloaded.
Closed issue #170 