### PR TITLE
Fix typo on start page. From 'Misson' to 'Mission'

### DIFF
--- a/src/i18n/po/template.pot
+++ b/src/i18n/po/template.pot
@@ -612,7 +612,7 @@ msgid "Mission"
 msgstr ""
 
 #: src/index.html:160
-msgid "Misson"
+msgid "Mission"
 msgstr ""
 
 #: src/contributors/index.html:214

--- a/src/index.html
+++ b/src/index.html
@@ -157,7 +157,7 @@
             <div class="mission-content">
               <div class="section-title w-clearfix">
                 <div class="section-title-line"></div>
-                <div class="section-title-text" translate>Misson</div>
+                <div class="section-title-text" translate>Mission</div>
               </div>
               <h1 class="fix mission-title" translate>Autonomy is self-rule. Stakeholders make the rules.</h1>
               <div class="mission-copy" translate>Since 2016, Decred has striven to solve blockchain governance. Our innovative consensus voting model empowers stakeholders and allows for the seamless transition from one set of rules to another. Decentralized decision-making and self-funding have enabled us to build a robust, evolving digital currency, free from third party influence.</div>


### PR DESCRIPTION
I don't know how the translation works and I haven't tested it. Someone with appropiate knowledge please make sure this PR doesn't break anything.