### PR TITLE
Fix JS error on home page

### DIFF
--- a/www-root/content/js/main.js
+++ b/www-root/content/js/main.js
@@ -627,19 +627,9 @@ $(window).load(function () {
 		$(".alldl").hide();
 	}
 
-	$('#mediaplayer').mediaelementplayer({
-		pluginPath: "/path/to/shims/",
-	// When using jQuery's `mediaelementplayer`, an `instance` argument
-	// is available in the `success` callback
-		success: function(mediaElement, originalNode, instance) {
-			// do things
-		}
-	});
-
-
-
-
-
+	if (typeof $('#mediaplayer').mediaelementplayer !== 'undefined') {
+        $('#mediaplayer').mediaelementplayer();
+	}
 });
 
 


### PR DESCRIPTION
Getting this error with Chrome and Firefox: `Uncaught TypeError: $(...).mediaelementplayer is not a function`

![2018-01-13-190309_781x71_scrot](https://user-images.githubusercontent.com/345702/34909245-552d1aaa-f895-11e7-890b-2696cfd6b657.png)

This seems to be a shim which is only defined for ancient browsers? I'm not sure whether it's actually used so I didn't remove it just in case.