### PR TITLE
Add missing language header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *~
 .vscode/
 node_modules/
-build/
-.tmp/
+
+/.tmp/
+/build/
+/package-lock.json

--- a/src/i18n/po/en.po
+++ b/src/i18n/po/en.po
@@ -4,6 +4,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: en\n"
 
 #: src/brand/index.html:149 src/contributors/index.html:294
 #: src/downloads/index.html:189 src/index.html:544 src/press/index.html:199


### PR DESCRIPTION
`grunt` would fail with this error:

```
Running "gt_generate_html:l10n" (gt_generate_html) task
WARNING: No Language header found for en!
```

Also added package-lock.json to .gitignore while I was at it. Let me know if this should be a separate PR.