### PR TITLE
Don't animate by stopping autoplay

### DIFF
--- a/www-root/content/js/main.js
+++ b/www-root/content/js/main.js
@@ -646,6 +646,6 @@ for (var i = 0; i < pathEls.length; i++) {
     loop: true,
     direction: 'alternate',
     easing: 'easeInOutSine',
-    autoplay: true
+    autoplay: false
   });
 }


### PR DESCRIPTION
Reduces CPU usage (mac, 2,5GHz Core i7) when looking on mission chart:
- Firefox 58.0 from 100% to 42%
- Chrome 63.0.3239.132 from 50% to 20%
- Safari 11.0.2 from 55% to 33%

CPU usage is also substantially reduced when scrolled away from the mission chart.

See issue #236