### PR TITLE
Fix for the `AH00534: httpd: Configuration error: No MPM loaded` issue

### DIFF
--- a/runtime/httpd.conf
+++ b/runtime/httpd.conf
@@ -173,6 +173,8 @@ LoadModule autoindex_module modules/mod_autoindex.so
 #LoadModule asis_module modules/mod_asis.so
 #LoadModule info_module modules/mod_info.so
 #LoadModule suexec_module modules/mod_suexec.so
+LoadModule mpm_worker_module modules/mod_mpm_worker.so
+
 <IfModule !mpm_prefork_module>
 	#LoadModule cgid_module modules/mod_cgid.so
 </IfModule>


### PR DESCRIPTION
Fix for the `AH00534: httpd: Configuration error: No MPM loaded` issue