### PR TITLE
Updated yarn.lock after run 'yarn' (version 1.3.2)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -57,8 +57,8 @@ applause@1.2.2:
     lodash "^3.10.0"
 
 argparse@^1.0.7:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.9.tgz#73d83bc263f86e97f8cc4f6bae1b0e90a7d22c86"
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
   dependencies:
     sprintf-js "~1.0.2"
 
@@ -672,6 +672,10 @@ lodash@^3.10.0, lodash@^3.10.1, lodash@^3.2.0:
 lodash@^4.0.0, lodash@^4.11.0, lodash@~4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+
+lodash@^4.11.0:
+  version "4.17.5"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 
 lodash@~0.9.2:
   version "0.9.2"


### PR DESCRIPTION
Update needed again, see last time https://github.com/decred/dcrweb/pull/237