### PR TITLE
Missing mpm_event module fix

### DIFF
--- a/Dockerfile-serve
+++ b/Dockerfile-serve
@@ -1,4 +1,4 @@
-FROM httpd:alpine
+FROM httpd:2.4
 
 LABEL description="dcrweb serve"
 LABEL version="1.0"


### PR DESCRIPTION
Use httpd:2.4 as base image - httpd:alping doesn't contain mpm modules