### PR TITLE
Fixed RocketChat 1200w image link

### DIFF
--- a/src/community/index.html
+++ b/src/community/index.html
@@ -109,7 +109,7 @@
           <div class="subpage-description" translate>Come and join our growing community, where you can connect with developers and other users, get information, ask questions, or just hang out.</div>
           <div class="subpage-content community">
             <a href="https://rocketchat.decred.org" target="_blank" class="community-card w-inline-block">
-              <div class="platform-image"><img src="/content/images/dcr-community-platforms-rocketchat.png" srcset="/content/images/dcr-community-platforms-rocketchat-p-500.png 500w, /content/images/dcr-community-platforms-rocketchat-p-800.png 800w, /content/images/dcr-community-platforms-rocketchat-p-1080.png 1080w, /content//content/images/dcr-community-platforms-rocketchat.png 1200w" sizes="(max-width: 479px) 92vw, (max-width: 767px) 100vw, (max-width: 991px) 96vw, 982px" class="platform-image-source"></div>
+              <div class="platform-image"><img src="/content/images/dcr-community-platforms-rocketchat.png" srcset="/content/images/dcr-community-platforms-rocketchat-p-500.png 500w, /content/images/dcr-community-platforms-rocketchat-p-800.png 800w, /content/images/dcr-community-platforms-rocketchat-p-1080.png 1080w, /content/images/dcr-community-platforms-rocketchat.png 1200w" sizes="(max-width: 479px) 92vw, (max-width: 767px) 100vw, (max-width: 991px) 96vw, 982px" class="platform-image-source"></div>
               <div class="platform-text-block">
                 <div class="platform-name">Rocket.Chat</div>
               </div>


### PR DESCRIPTION
The RocketChat image on the community page was not loading since the URL had a duplicate "/content" in the address