### PR TITLE
version bump to 1.2.0 for download links

### DIFF
--- a/src/brand/index.html
+++ b/src/brand/index.html
@@ -148,7 +148,7 @@
           <div class="footerrowscolumn1 w-col w-col-3 w-col-medium-3"><a href="#" class="footerblocklink transition" translate>Brand Resources</a><a href="../press/" class="footerblocklink transition" translate>Decred in the Press</a><a href="../recruiting" target="_blank" class="footerblocklink transition" translate>Become a Contributor</a></div>
           <div class="footerrowscolumn1 w-col w-col-2 w-col-medium-2"><a href="https://docs.decred.org/research/overview/" target="_blank" class="footerblocklink transition" translate>Technical Overview</a><a href="/business_brief.pdf" target="_blank" class="footerblocklink transition" translate>Business Brief</a><a href="https://blog.decred.org/2018/02/28/2018-Decred-Roadmap/" target="_blank" class="footerblocklink transition" translate>2018 Roadmap</a></div>
           <div class="footerblockstats footerrowscolumn1 w-clearfix w-col w-col-2 w-col-medium-2">
-            <div class="footerblockstatsrow w-clearfix"><a id="footerRelease" class="backgroundturquoise borderradius4 dropshadow footerblockstatslink" href="https://github.com/decred/decred-release/releases/tag/v1.1.0" target="_blank">v1.1.0</a>
+            <div class="footerblockstatsrow w-clearfix"><a id="footerRelease" class="backgroundturquoise borderradius4 dropshadow footerblockstatslink" href="https://github.com/decred/decred-release/releases/tag/v1.2.0" target="_blank">v1.2.0</a>
               <div class="footerblockstatsname" translate>stable</div>
             </div>
             <div class="footerblockstatsrow w-clearfix"><a href="../downloads/" id="footerDownloads" class="backgroundwashedblue borderradius4 dropshadow footerblockstatslink">52k total</a>

--- a/src/community/index.html
+++ b/src/community/index.html
@@ -201,7 +201,7 @@
           <div class="footerrowscolumn1 w-col w-col-3 w-col-medium-3"><a href="../brand/" class="footerblocklink transition" translate>Brand Resources</a><a href="../press/" class="footerblocklink transition" translate>Decred in the Press</a><a href="../recruiting" target="_blank" class="footerblocklink transition" translate>Become a Contributor</a></div>
           <div class="footerrowscolumn1 w-col w-col-2 w-col-medium-2"><a href="https://docs.decred.org/research/overview/" target="_blank" class="footerblocklink transition" translate>Technical Overview</a><a href="/business_brief.pdf" target="_blank" class="footerblocklink transition" translate>Business Brief</a><a href="https://blog.decred.org/2018/02/28/2018-Decred-Roadmap/" target="_blank" class="footerblocklink transition" translate>2018 Roadmap</a></div>
           <div class="footerblockstats footerrowscolumn1 w-clearfix w-col w-col-2 w-col-medium-2">
-            <div class="footerblockstatsrow w-clearfix"><a id="footerRelease" class="backgroundturquoise borderradius4 dropshadow footerblockstatslink" href="https://github.com/decred/decred-release/releases/tag/v1.1.2" target="_blank">v1.1.2</a>
+            <div class="footerblockstatsrow w-clearfix"><a id="footerRelease" class="backgroundturquoise borderradius4 dropshadow footerblockstatslink" href="https://github.com/decred/decred-release/releases/tag/v1.2.0" target="_blank">v1.2.0</a>
               <div class="footerblockstatsname" translate>stable</div>
             </div>
             <div class="footerblockstatsrow w-clearfix"><a id="footerDownloads" class="backgroundwashedblue borderradius4 dropshadow footerblockstatslink">52k total</a>

--- a/src/contributors/index.html
+++ b/src/contributors/index.html
@@ -383,7 +383,7 @@
           <div class="footerrowscolumn1 w-col w-col-3 w-col-medium-3"><a href="../brand/" class="footerblocklink transition" translate>Brand Resources</a><a href="../press/" class="footerblocklink transition" translate>Decred in the Press</a><a href="../recruiting" target="_blank" class="footerblocklink transition" translate>Become a Contributor</a></div>
           <div class="footerrowscolumn1 w-col w-col-2 w-col-medium-2"><a href="https://docs.decred.org/research/overview/" target="_blank" class="footerblocklink transition" translate>Technical Overview</a><a href="/business_brief.pdf" target="_blank" class="footerblocklink transition" translate>Business Brief</a><a href="https://blog.decred.org/2018/02/28/2018-Decred-Roadmap/" target="_blank" class="footerblocklink transition" translate>2018 Roadmap</a></div>
           <div class="footerblockstats footerrowscolumn1 w-clearfix w-col w-col-2 w-col-medium-2">
-            <div class="footerblockstatsrow w-clearfix"><a id="footerRelease" class="backgroundturquoise borderradius4 dropshadow footerblockstatslink" href="https://github.com/decred/decred-release/releases/tag/v1.1.0" target="_blank">v1.1.0</a>
+            <div class="footerblockstatsrow w-clearfix"><a id="footerRelease" class="backgroundturquoise borderradius4 dropshadow footerblockstatslink" href="https://github.com/decred/decred-release/releases/tag/v1.2.0" target="_blank">v1.2.0</a>
               <div class="footerblockstatsname" translate>stable</div>
             </div>
             <div class="footerblockstatsrow w-clearfix"><a id="footerDownloads" class="backgroundwashedblue borderradius4 dropshadow footerblockstatslink" href="../downloads/" >52k total</a>

--- a/src/downloads/index.html
+++ b/src/downloads/index.html
@@ -128,9 +128,9 @@
               <div class="section-card-download-page" id="decrediton">
                   <div class="decrediton section-card-title-download-page" translate>Decrediton</div>
                   <div class="section-card-description-download" translate>Graphic UI wallet for Windows, macOS and Linux.</div>
-                  <div class="section-card-download-links-download-page w-clearfix"><a target="_blank" href="https://github.com/decred/decred-binaries/releases/download/v1.1.3/decrediton-v1.1.3.exe" class="section-card-link-download-page" translate>Windows ↓</a>
-                    <div class="seperator"></div><a target="_blank" href="https://github.com/decred/decred-binaries/releases/download/v1.1.3/decrediton-v1.1.3.dmg" class="section-card-link-download-page" translate>macOS ↓</a>
-                    <div class="seperator"></div><a target="_blank" href="https://github.com/decred/decred-binaries/releases/download/v1.1.3/decrediton-v1.1.3.tar.gz" class="section-card-link-download-page" translate>Linux 64-bit ↓</a>
+                  <div class="section-card-download-links-download-page w-clearfix"><a target="_blank" href="https://github.com/decred/decred-binaries/releases/download/v1.2.0/decrediton-v1.2.0.exe" class="section-card-link-download-page" translate>Windows ↓</a>
+                    <div class="seperator"></div><a target="_blank" href="https://github.com/decred/decred-binaries/releases/download/v1.2.0/decrediton-v1.2.0.dmg" class="section-card-link-download-page" translate>macOS ↓</a>
+                    <div class="seperator"></div><a target="_blank" href="https://github.com/decred/decred-binaries/releases/download/v1.2.0/decrediton-v1.2.0.tar.gz" class="section-card-link-download-page" translate>Linux 64-bit ↓</a>
                   </div>
                 </div>
               <div class="section-card-download-page" id="webwallet">
@@ -141,7 +141,7 @@
               <div class="section-card-download-page" id="cli">
                 <div class="commandline section-card-title-download-page" translate>Command-line app suite</div>
                 <div class="section-card-description-download" translate>A cross-platform, automatic installer/updater for the command-line applications.</div>
-                <div class="section-card-download-links-download-page w-clearfix"><a target="_blank" href="https://github.com/decred/decred-release/releases/tag/v1.1.2" class="section-card-link-download-page" translate>View on Github →</a></div>
+                <div class="section-card-download-links-download-page w-clearfix"><a target="_blank" href="https://github.com/decred/decred-release/releases/tag/v1.2.0" class="section-card-link-download-page" translate>View on Github →</a></div>
               </div>
             </div>
             <div class="section-download-page w-clearfix">
@@ -181,7 +181,7 @@
           <div class="footerrowscolumn1 w-col w-col-3 w-col-medium-3"><a href="../brand/" class="footerblocklink transition" translate>Brand Resources</a><a href="../press/" class="footerblocklink transition" translate>Decred in the Press</a><a href="../recruiting" target="_blank" class="footerblocklink transition" translate>Become a Contributor</a></div>
           <div class="footerrowscolumn1 w-col w-col-2 w-col-medium-2"><a href="https://docs.decred.org/research/overview/" target="_blank" class="footerblocklink transition" translate>Technical Overview</a><a href="/business_brief.pdf" target="_blank" class="footerblocklink transition" translate>Business Brief</a><a href="https://blog.decred.org/2018/02/28/2018-Decred-Roadmap/" target="_blank" class="footerblocklink transition" translate>2018 Roadmap</a></div>
           <div class="footerblockstats footerrowscolumn1 w-clearfix w-col w-col-2 w-col-medium-2">
-            <div class="footerblockstatsrow w-clearfix"><a id="footerRelease" class="backgroundturquoise borderradius4 dropshadow footerblockstatslink" href="https://github.com/decred/decred-release/releases/tag/v1.1.2" target="_blank">v1.1.2</a>
+            <div class="footerblockstatsrow w-clearfix"><a id="footerRelease" class="backgroundturquoise borderradius4 dropshadow footerblockstatslink" href="https://github.com/decred/decred-release/releases/tag/v1.2.0" target="_blank">v1.2.0</a>
               <div class="footerblockstatsname" translate>stable</div>
             </div>
             <div class="footerblockstatsrow w-clearfix"><a id="footerDownloads" class="backgroundwashedblue borderradius4 dropshadow footerblockstatslink">52k total</a>

--- a/src/exchanges/index.html
+++ b/src/exchanges/index.html
@@ -336,7 +336,7 @@
             <div class="footerrowscolumn1 w-col w-col-3 w-col-medium-3"><a href="../brand/" class="footerblocklink transition" translate>Brand Resources</a><a href="../press/" class="footerblocklink transition" translate>Decred in the Press</a><a href="../recruiting" target="_blank" class="footerblocklink transition" translate>Become a Contributor</a></div>
             <div class="footerrowscolumn1 w-col w-col-2 w-col-medium-2"><a href="https://docs.decred.org/research/overview/" target="_blank" class="footerblocklink transition" translate>Technical Overview</a><a href="/business_brief.pdf" target="_blank" class="footerblocklink transition" translate>Business Brief</a><a href="https://blog.decred.org/2018/02/28/2018-Decred-Roadmap/" target="_blank" class="footerblocklink transition" translate>2018 Roadmap</a></div>
             <div class="footerblockstats footerrowscolumn1 w-clearfix w-col w-col-2 w-col-medium-2">
-              <div class="footerblockstatsrow w-clearfix"><a id="footerRelease" class="backgroundturquoise borderradius4 dropshadow footerblockstatslink" href="https://github.com/decred/decred-release/releases/tag/v1.1.2" target="_blank">v1.1.2</a>
+              <div class="footerblockstatsrow w-clearfix"><a id="footerRelease" class="backgroundturquoise borderradius4 dropshadow footerblockstatslink" href="https://github.com/decred/decred-release/releases/tag/v1.2.0" target="_blank">v1.2.0</a>
                 <div class="footerblockstatsname" translate>stable</div>
               </div>
               <div class="footerblockstatsrow w-clearfix"><a id="footerDownloads" class="backgroundwashedblue borderradius4 dropshadow footerblockstatslink">52k total</a>

--- a/src/index.html
+++ b/src/index.html
@@ -138,11 +138,11 @@
 
           <div class="first-view-buttons w-clearfix">
             <a href="downloads/" class="button download-wallet w-button alldl"><span translate>Download Wallet</span></a><div class="button os-specific alldl"><span translate>For Your Computer</span></div>
-            <a href="https://github.com/decred/decred-binaries/releases/download/v1.1.3/decrediton-v1.1.3.dmg" class="button download-wallet w-button macdl"><span translate>Download Wallet</span></a><div class="button os-specific macdl"><span translate>Decrediton For Mac OS X</span></div>
-            <a href="https://github.com/decred/decred-binaries/releases/download/v1.1.3/decrediton-v1.1.3.tar.gz" class="button download-wallet w-button linuxdl"><span translate>Download Wallet</span></a><div class="button os-specific linuxdl"><span translate>Decrediton For Linux</span></div>
-            <a href="https://github.com/decred/decred-binaries/releases/download/v1.1.3/decrediton-v1.1.3.exe" class="button download-wallet w-button win32dl"><span translate>Download Wallet</span></a><div class="button os-specific win32dl"><span translate>Decrediton For Windows 32bit</span></div>
-            <a href="https://github.com/decred/decred-binaries/releases/download/v1.1.3/decrediton-v1.1.3.exe" class="button download-wallet w-button win64dl"><span translate>Download Wallet</span></a><div class="button os-specific win64dl"><span translate>Decrediton For Windows 64bit</span></div>
-            <a href="https://github.com/decred/decred-binaries/releases/download/v1.1.3/decrediton-v1.1.3.exe" class="button download-wallet w-button windl"><span translate>Download Wallet</span></a><div class="button os-specific windl"><span translate>Decrediton For Windows</span></div>
+            <a href="https://github.com/decred/decred-binaries/releases/download/v1.2.0/decrediton-v1.2.0.dmg" class="button download-wallet w-button macdl"><span translate>Download Wallet</span></a><div class="button os-specific macdl"><span translate>Decrediton For Mac OS X</span></div>
+            <a href="https://github.com/decred/decred-binaries/releases/download/v1.2.0/decrediton-v1.2.0.tar.gz" class="button download-wallet w-button linuxdl"><span translate>Download Wallet</span></a><div class="button os-specific linuxdl"><span translate>Decrediton For Linux</span></div>
+            <a href="https://github.com/decred/decred-binaries/releases/download/v1.2.0/decrediton-v1.2.0.exe" class="button download-wallet w-button win32dl"><span translate>Download Wallet</span></a><div class="button os-specific win32dl"><span translate>Decrediton For Windows 32bit</span></div>
+            <a href="https://github.com/decred/decred-binaries/releases/download/v1.2.0/decrediton-v1.2.0.exe" class="button download-wallet w-button win64dl"><span translate>Download Wallet</span></a><div class="button os-specific win64dl"><span translate>Decrediton For Windows 64bit</span></div>
+            <a href="https://github.com/decred/decred-binaries/releases/download/v1.2.0/decrediton-v1.2.0.exe" class="button download-wallet w-button windl"><span translate>Download Wallet</span></a><div class="button os-specific windl"><span translate>Decrediton For Windows</span></div>
             <a href="downloads/" class="button all-downloads w-button" translate>All Downloads →</a>
           </div>
 
@@ -551,7 +551,7 @@ We can't wait to meet you!</p></div>
           <div class="footerrowscolumn1 w-col w-col-3 w-col-medium-3"><a href="brand/" class="footerblocklink transition" translate>Brand Resources</a><a href="press/" class="footerblocklink transition" translate>Decred in the Press</a><a href="recruiting/" target="_blank" class="footerblocklink transition" translate>Become a Contributor</a></div>
           <div class="footerrowscolumn1 w-col w-col-2 w-col-medium-2"><a href="https://docs.decred.org/research/overview/" target="_blank" class="footerblocklink transition" translate>Technical Overview</a><a href="/business_brief.pdf" target="_blank" class="footerblocklink transition" translate>Business Brief</a><a href="https://blog.decred.org/2018/02/28/2018-Decred-Roadmap/" target="_blank" class="footerblocklink transition" translate>2018 Roadmap</a></div>
           <div class="footerblockstats footerrowscolumn1 w-clearfix w-col w-col-2 w-col-medium-2">
-            <div class="footerblockstatsrow w-clearfix"><a id="footerRelease" class="backgroundturquoise borderradius4 dropshadow footerblockstatslink" href="https://github.com/decred/decred-release/releases/tag/v1.1.2" target="_blank">v1.1.2</a>
+            <div class="footerblockstatsrow w-clearfix"><a id="footerRelease" class="backgroundturquoise borderradius4 dropshadow footerblockstatslink" href="https://github.com/decred/decred-release/releases/tag/v1.2.0" target="_blank">v1.2.0</a>
               <div class="footerblockstatsname" translate>stable</div>
             </div>
             <div class="footerblockstatsrow w-clearfix"><a id="footerDownloads" class="backgroundwashedblue borderradius4 dropshadow footerblockstatslink" href="downloads/">52k total</a>

--- a/src/press/index.html
+++ b/src/press/index.html
@@ -198,7 +198,7 @@
           <div class="footerrowscolumn1 w-col w-col-3 w-col-medium-3"><a href="../brand/" class="footerblocklink transition" translate>Brand Resources</a><a href="#" class="footerblocklink transition" translate>Decred in the Press</a><a href="../recruiting" target="_blank" class="footerblocklink transition" translate>Become a Contributor</a></div>
           <div class="footerrowscolumn1 w-col w-col-2 w-col-medium-2"><a href="https://docs.decred.org/research/overview/" target="_blank" class="footerblocklink transition" translate>Technical Overview</a><a href="/business_brief.pdf" target="_blank" class="footerblocklink transition" translate>Business Brief</a></div>
           <div class="footerblockstats footerrowscolumn1 w-clearfix w-col w-col-2 w-col-medium-2">
-            <div class="footerblockstatsrow w-clearfix"><a id="footerRelease" class="backgroundturquoise borderradius4 dropshadow footerblockstatslink" href="https://github.com/decred/decred-release/releases/tag/v1.1.0" target="_blank">v1.1.0</a>
+            <div class="footerblockstatsrow w-clearfix"><a id="footerRelease" class="backgroundturquoise borderradius4 dropshadow footerblockstatslink" href="https://github.com/decred/decred-release/releases/tag/v1.2.0" target="_blank">v1.2.0</a>
               <div class="footerblockstatsname" translate>stable</div>
             </div>
             <div class="footerblockstatsrow w-clearfix"><a id="footerDownloads" class="backgroundwashedblue borderradius4 dropshadow footerblockstatslink" href="../downloads/">52k total</a>

--- a/src/stakepools/index.html
+++ b/src/stakepools/index.html
@@ -151,7 +151,7 @@
           <div class="footerrowscolumn1 w-col w-col-3 w-col-medium-3"><a href="../brand/" class="footerblocklink transition" translate>Brand Resources</a><a href="../press/" class="footerblocklink transition" translate>Decred in the Press</a><a href="../recruiting" target="_blank" class="footerblocklink transition" translate>Become a Contributor</a></div>
           <div class="footerrowscolumn1 w-col w-col-2 w-col-medium-2"><a href="https://docs.decred.org/research/overview/" target="_blank" class="footerblocklink transition" translate>Technical Overview</a><a href="/business_brief.pdf" target="_blank" class="footerblocklink transition" translate>Business Brief</a><a href="https://blog.decred.org/2018/02/28/2018-Decred-Roadmap/" target="_blank" class="footerblocklink transition" translate>2018 Roadmap</a></div>
           <div class="footerblockstats footerrowscolumn1 w-clearfix w-col w-col-2 w-col-medium-2">
-            <div class="footerblockstatsrow w-clearfix"><a id="footerRelease" class="backgroundturquoise borderradius4 dropshadow footerblockstatslink" href="https://github.com/decred/decred-release/releases/tag/v1.1.0" target="_blank">v1.1.0</a>
+            <div class="footerblockstatsrow w-clearfix"><a id="footerRelease" class="backgroundturquoise borderradius4 dropshadow footerblockstatslink" href="https://github.com/decred/decred-release/releases/tag/v1.2.0" target="_blank">v1.2.0</a>
               <div class="footerblockstatsname" translate>stable</div>
             </div>
             <div class="footerblockstatsrow w-clearfix"><a id="footerDownloads" class="backgroundwashedblue borderradius4 dropshadow footerblockstatslink" href="../downloads/" >52k total</a>


### PR DESCRIPTION
prepared: download links updates to the latest version 1.2.0
used download links:
Mac:
https://github.com/decred/decred-binaries/releases/download/v1.2.0/decrediton-v1.2.0.dmg
Linux:
https://github.com/decred/decred-binaries/releases/download/v1.2.0/decrediton-v1.2.0.tar.gz
Win:
https://github.com/decred/decred-binaries/releases/download/v1.2.0/decrediton-v1.2.0.exe
DCRinstall:
https://github.com/decred/decred-release/releases/tag/v1.2.0