### PR TITLE
Fixed to use new image

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "grunt",
     "build:development": "BUILD_ENV=development grunt",
     "deploy:build": "yarn run build",
-    "deploy:build:docker": "yarn run build && docker build -t decred/dcrweb -f Dockerfile-serve .",
+    "deploy:build:docker": "yarn run build && docker build -t decred/dcrweb -f Dockerfile .",
     "deploy:preflight": "yarn run deploy:build:docker && docker run -p 8080:80 --rm decred/dcrweb",
     "deploy:run": "docker run -d -p 80:80 decred/dcrweb",
     "dev": "yarn deploy:build:docker && docker run -p 8080:80 --rm -v `pwd`/docker-build:/usr/local/apache2/htdocs decred/dcrweb"


### PR DESCRIPTION
My last pull request broke the yarn dev command because the used Dockerfile has been removed.  Updated package.json to use the new.  This is not ideal because building the image involves steps that are not required for development, but it's not a real problem.