### PR TITLE
Update httpd.conf

### DIFF
--- a/runtime/httpd.conf
+++ b/runtime/httpd.conf
@@ -40,6 +40,11 @@ ServerRoot "/usr/local/apache2"
 #
 # Mutex default:logs
 
+#Security Headers
+Header set X-Frame-Options SAMEORIGIN
+Header set X-XSS-Protection 1;mode=block
+Header set X-Content-Type-Options nosniff
+
 #
 # Listen: Allows you to bind Apache to specific IP addresses and/or
 # ports, instead of the default. See also the <VirtualHost>


### PR DESCRIPTION
X-Frame-Options SAMEORIGIN prevents click jacking type attacks while allowing Iframe's from the website to itself to work.
X-XSS-Protection 1;mode=block enforces XSS prevention on browsers, this would protect against future XSS attacks.
X-Content-Type-Options nosniff fixes MIME-type confusion.