### PR TITLE
Fix ShapeShift link and liquidity filter

### DIFF
--- a/src/exchanges/index.html
+++ b/src/exchanges/index.html
@@ -139,11 +139,12 @@
           </div>
           <div class="subpage-content exchanges">
             <div class="filter-cards-wrap w-clearfix">
-              <a href="https://altcoin.io" target="_blank" data-groups="[&quot;instant-exchange&quot;]" class="filter-card w-inline-block">
+              <a href="https://shapeshift.io/" target="_blank" data-groups="[&quot;instant-exchange&quot;]" class="filter-card w-inline-block">
                 <div class="filter-card-image-wrap"><img src="/content/images/Shapeshift.jpg" srcset="/content/images/Shapeshift-p-500.jpeg 500w, /content/images/Shapeshift.jpg 608w" sizes="(max-width: 767px) 100vw, (max-width: 991px) 229px, 306.65625px" class="filter-card-image"></div>
                 <div class="filter-card-footer w-clearfix">
                   <div class="filter-card-title">ShapeShift</div>
                   <div tail="Instant exchange" class="filter-button instant-exchange is-checked"></div>
+                  <div tail="High liquidity" class="filter-button high-liquidity is-checked"></div>
                 </div>
               </a>
               <a target="_blank" href="https://flyp.me/" data-groups="[&quot;instant-exchange&quot;]" class="filter-card w-inline-block">
@@ -212,7 +213,6 @@
                 <div class="filter-card-image-wrap"><img src="/content/images/Zhaobi.jpg" srcset="/content/images/Zhaobi-p-500.jpeg 500w, /content/images/Zhaobi.jpg 608w" sizes="(max-width: 767px) 100vw, (max-width: 991px) 229px, 306.65625px" class="filter-card-image"></div>
                 <div class="filter-card-footer w-clearfix">
                   <div class="filter-card-title">Zhaobi</div>
-                  <div tail="High liquidity" class="filter-button high-liquidity is-checked"></div>
                 </div>
               </a>
               <a target="_blank" href="https://holytransaction.com/" data-groups="[&quot;all&quot;]" class="filter-card un-categorized w-inline-block">
@@ -226,7 +226,6 @@
                 <div class="filter-card-footer w-clearfix">
                   <div class="filter-card-title">CoinSpot</div>
                   <div tail="Fiat" class="filter-button fiat is-checked"></div>
-                  <div tail="High liquidity" class="filter-button high-liquidity is-checked"></div>
                 </div>
               </a>
               <a target="_blank" href="https://bisq.network" data-groups="[&quot;high-liquidity&quot;,&quot;atomic-swaps&quot;,&quot;decentralized&quot;]" class="filter-card w-inline-block">
@@ -235,7 +234,6 @@
                   <div class="filter-card-title">Bisq</div>
                   <div tail="Decentralized" class="filter-button decentralized is-checked"></div>
                   <div tail="Atomic swaps" class="filter-button atomic-swaps is-checked"></div>
-                  <div tail="High liquidity" class="filter-button high-liquidity is-checked"></div>
                 </div>
               </a>
               <a target="_blank" href="https://tuxexchange.com/" data-groups="[&quot;all&quot;]" class="filter-card w-inline-block">
@@ -248,7 +246,6 @@
                 <div class="filter-card-image-wrap"><img src="/content/images/cryptopiacryptopia.jpg" srcset="/content/images/cryptopiacryptopia-p-500.jpeg 500w, /content/images/cryptopiacryptopia.jpg 608w" sizes="(max-width: 767px) 100vw, (max-width: 991px) 229px, 306.65625px" class="filter-card-image"></div>
                 <div class="filter-card-footer w-clearfix">
                   <div class="filter-card-title">CRYPTOPIA</div>
-                  <div tail="High liquidity" class="filter-button high-liquidity is-checked"></div>
                 </div>
               </a>
               <a target="_blank" href="https://changenow.io" data-groups="[&quot;fiat&quot;,&quot;instant-exchange&quot;]" class="filter-card w-inline-block">


### PR DESCRIPTION
ShapeShift was pointing to the wrong site and many of the exchanges being filtered as "high liquidity" have little to no volume.