### PR TITLE
Update contributors to reflect Twitter changes.

### DIFF
--- a/src/contributors/index.html
+++ b/src/contributors/index.html
@@ -424,6 +424,12 @@
                 <div class="team-member-title" translate>Decred Assembly Host</div>
                 <div class="team-member-social"><a target="_blank" href="https://decred.slack.com/team/U7190LS75" class="slack team-member-social-link w-inline-block"><img src="/content/images/team_slack.svg" class="team-member-social-link-image"></a><a target="_blank" href="https://twitter.com/traceagain" class="twitter team-member-social-link w-inline-block"><img src="/content/images/team_twitter.svg" class="team-member-social-link-image"></a></div>
               </div>
+              <div data-name="phillip conrad" data-slack="ingsoc" data-twitter="realingsoc" data-filter="community" class="team-member w-clearfix">
+                <div class="team-member-avatar"><img src="/content/images/team_21.svg" class="image"></div>
+                <div class="team-member-name">Phillip Conrad</div>
+                <div class="team-member-title" translate>Twitter Ops</div>
+                <div class="team-member-social"><a target="_blank" href="https://decred.slack.com/team/U0NRS2FKN" class="slack team-member-social-link w-inline-block"><img src="/content/images/team_slack.svg" class="team-member-social-link-image"></a><a target="_blank" href="https://twitter.com/realingsoc" class="twitter team-member-social-link w-inline-block"><img src="/content/images/team_twitter.svg" class="team-member-social-link-image"></a></div>
+              </div>
               <div data-name="bab" data-slack="BAB" data-corporate-name="Company One LLC" data-twitter="@DeCredBAB" data-filter="marketing" class="team-member w-clearfix">
                 <div class="team-member-avatar"><img src="/content/images/team_44.svg" class="image"></div>
                 <div class="team-member-name">Clarissa Peereboom</div>
@@ -459,12 +465,6 @@
                 <div class="team-member-name">Jonathan Zeppettini</div>
                 <div class="team-member-title" translate>International Ops Lead</div>
                 <div class="team-member-social"><a target="_blank" href="https://decred.slack.com/team/U40F6GKNU" class="slack team-member-social-link w-inline-block"><img src="/content/images/team_slack.svg" class="team-member-social-link-image"></a><a target="_blank" href="https://twitter.com/jz_bz" class="twitter team-member-social-link w-inline-block"><img src="/content/images/team_twitter.svg" class="team-member-social-link-image"></a></div>
-              </div>
-              <div data-name="phillip conrad" data-slack="ingsoc" data-twitter="realingsoc" data-filter="strategy" class="team-member w-clearfix">
-                <div class="team-member-avatar"><img src="/content/images/team_21.svg" class="image"></div>
-                <div class="team-member-name">Phillip Conrad</div>
-                <div class="team-member-title" translate>Strategic Comms Lead</div>
-                <div class="team-member-social"><a target="_blank" href="https://decred.slack.com/team/U0NRS2FKN" class="slack team-member-social-link w-inline-block"><img src="/content/images/team_slack.svg" class="team-member-social-link-image"></a><a target="_blank" href="https://twitter.com/realingsoc" class="twitter team-member-social-link w-inline-block"><img src="/content/images/team_twitter.svg" class="team-member-social-link-image"></a></div>
               </div>
               <div class="my-sizer-element"></div>
             </div>


### PR DESCRIPTION
Contribution to the @decredproject Twitter account has evolved over the past few months. A #twitter_ops channel is being used on Slack and Matrix to collaboratively draft and execute project tweets (including retweets). Anyone with an interest in contributing to the Twitter account can ask for an invitation to the channel and can start contributing content and ideas there for evaluation by the Twitter group. As a result, no minority or unilateral veto over tweets is possible. Accordingly, I'm submitting this pull request for consideration and to reflect the change.