### PR TITLE
add extended version via url on compare page

### DIFF
--- a/src/compare/index.html
+++ b/src/compare/index.html
@@ -44,7 +44,7 @@
     <div class="subheader">
       <div class="section row r-masks w-clearfix">
         <div class="cell c-expand w-clearfix">
-          <div tail="Extended chart" class="mask extended"></div>
+          <div tail="Extended chart" class="mask extended" id="extendedburger"></div>
         </div>
         <div class="cell c-masks w-clearfix">
           <div tail="Awesome!" class="mask awesome dash"></div>

--- a/www-root/content/js/page-comparison-chart.js
+++ b/www-root/content/js/page-comparison-chart.js
@@ -118,6 +118,11 @@ $(window).load(function() {
         tail.text(that.attr('tail'));
     });
 
-
+    if (window.location.hash){
+        var hash = window.location.hash.substring(1);
+        if (hash == "extended"){
+            $('#extendedburger').click()
+        }
+     }
 
 });


### PR DESCRIPTION
now you can hand out links to the compare sub page and have it in an extended version per default
just give out the link with an additional hash #extended like:
https://decred.org/compare/#extended
fixes #213