### PR TITLE
Add link to release notes on download page

### DIFF
--- a/src/downloads/index.html
+++ b/src/downloads/index.html
@@ -129,14 +129,20 @@
                   <div class="decrediton section-card-title-download-page" translate>Decrediton</div>
                   <div class="section-card-description-download" translate>Graphic UI wallet for Windows, macOS and Linux.</div>
                   <div class="section-card-download-links-download-page w-clearfix"><a target="_blank" rel="noopener noreferrer" href="https://github.com/decred/decred-binaries/releases/download/v1.3.0/decrediton-v1.3.0.exe" id="decreditonwindows" class="section-card-link-download-page" translate>Windows ↓</a>
-                    <div class="seperator"></div><a target="_blank" rel="noopener noreferrer" href="https://github.com/decred/decred-binaries/releases/download/v1.3.0/decrediton-v1.3.0.dmg" class="section-card-link-download-page" id="decreditonmac" translate>macOS ↓</a>
-                    <div class="seperator"></div><a target="_blank" rel="noopener noreferrer" href="https://github.com/decred/decred-binaries/releases/download/v1.3.0/decrediton-v1.3.0.tar.gz" class="section-card-link-download-page" id="decreditonlinux" translate>Linux 64-bit ↓</a>
+                    <div class="separator"></div><a target="_blank" rel="noopener noreferrer" href="https://github.com/decred/decred-binaries/releases/download/v1.3.0/decrediton-v1.3.0.dmg" class="section-card-link-download-page" id="decreditonmac" translate>macOS ↓</a>
+                    <div class="separator"></div><a target="_blank" rel="noopener noreferrer" href="https://github.com/decred/decred-binaries/releases/download/v1.3.0/decrediton-v1.3.0.tar.gz" class="section-card-link-download-page" id="decreditonlinux" translate>Linux 64-bit ↓</a>
+                  </div>
+                  <div class="section-card-download-links-download-page w-clearfix"><a target="_blank" rel="noopener noreferrer" href="https://github.com/decred/decred-binaries/blob/master/release-notes.md#decrediton-v130" class="section-card-link-download-page" translate>Release notes →</a>
                   </div>
                 </div>
               <div class="section-card-download-page" id="cli">
                 <div class="commandline section-card-title-download-page" translate>Command-line app suite</div>
                 <div class="section-card-description-download" translate>A cross-platform, automatic installer/updater for the command-line applications.</div>
-                <div class="section-card-download-links-download-page w-clearfix"><a target="_blank" rel="noopener noreferrer" href="https://github.com/decred/decred-release/releases/tag/v1.3.0" class="section-card-link-download-page" translate>View on Github →</a></div>
+                <div class="section-card-download-links-download-page w-clearfix">
+                  <a target="_blank" rel="noopener noreferrer" href="https://github.com/decred/decred-release/releases/tag/v1.3.0" class="section-card-link-download-page" translate>View on Github →</a>
+                  <div class="separator"></div>
+                  <a target="_blank" rel="noopener noreferrer" href="https://github.com/decred/decred-binaries/blob/master/release-notes.md#dcrd-v130" class="section-card-link-download-page" translate>Release notes →</a>
+                </div>
               </div>
             </div>
             <div class="section-download-page w-clearfix">
@@ -178,7 +184,7 @@
                 <div class="anybit section-card-title-download-page" translate>AnyBit</div>
                 <div class="section-card-description-download" translate>Anybit is a mobile wallet available for Android and iOS with built in price and news tracking.</div>
                 <div class="section-card-download-links-download-page w-clearfix"><a target="_blank" rel="noopener noreferrer" href="https://www.anybit.io/" class="section-card-link-download-page" translate>AnyBit releases →</a></div>
-              </div> 
+              </div>
               <div class="section-card-download-page third-party" id="atomicwallet">
                 <div class="atomicwallet section-card-title-download-page" translate>Atomic</div>
                 <div class="section-card-description-download" translate>Multi-asset desktop wallet with built in exchange via non-custodial atomic swaps and decentralized order book.</div>
@@ -193,7 +199,7 @@
                 <div class="cobo section-card-title-download-page" translate>Cobo</div>
                 <div class="section-card-description-download" translate>From the Co-Founder of F2Pool, Cobo is a highly secure mobile wallet that supports PoS Cloud Pool staking and over 30 coins and 500 tokens.</div>
                 <div class="section-card-download-links-download-page w-clearfix"><a target="_blank" rel="noopener noreferrer" href="https://cobo.com" class="section-card-link-download-page" translate>Cobo releases →</a></div>
-              </div>                                          
+              </div>
             </div>
           </div>
         </div>

--- a/www-root/content/css/decred-v5-nojs-edition.css
+++ b/www-root/content/css/decred-v5-nojs-edition.css
@@ -1962,7 +1962,7 @@ body {
   float: left;
 }
 
-.seperator {
+.separator {
   width: 1px;
   height: 16px;
   margin-top: 1px;

--- a/www-root/content/css/decred-v5.css
+++ b/www-root/content/css/decred-v5.css
@@ -2193,7 +2193,7 @@ body {
   float: left;
 }
 
-.seperator {
+.separator {
   width: 1px;
   height: 16px;
   margin-top: 1px;


### PR DESCRIPTION
With each new release it takes me a little while to find the release notes so I think having a link on the download page would be appreciated by most people considering Decred users are fairly tech savvy (at least for the time being.)

Screenshot:

![screenshot_2018-09-25 decred downloads](https://user-images.githubusercontent.com/345702/46020752-9b885800-c0ce-11e8-8292-5694d877995d.png)

See also https://github.com/decred/decred-binaries/pull/77#issuecomment-423934181