### PR TITLE
Link to Decred Matrix homeserver by default

### DIFF
--- a/src/community/index.html
+++ b/src/community/index.html
@@ -102,7 +102,7 @@
         <div class="subpage-content-section">
           <div class="subpage-description" translate>Come and join our growing community, where you can connect with developers and other users, get information, ask questions, or just hang out. The public channels on Matrix, Slack, Discord and Rocket.Chat have been bridged. You can choose any of these platforms and still participate in discussions with Decred community members on the others.</div>
           <div class="subpage-content community">
-            <a href="https://matrix.to/#/+decred:decred.org" target="_blank" rel="noopener noreferrer" class="community-card w-inline-block">
+            <a href="https://riot.im/app/#/register?hs_url=https://matrix.decred.org" target="_blank" rel="noopener noreferrer" class="community-card w-inline-block">
               <div class="platform-image"><img alt=""  src="/content/images/dcr-community-platforms-riotim.png" srcset="/content/images/dcr-community-platforms-riotim-p-500.png 500w, /content/images/dcr-community-platforms-riotim-p-800.png 800w, /content/images/dcr-community-platforms-riotim-p-1080.png 1080w, /content/images/dcr-community-platforms-riotim.png 1200w" sizes="(max-width: 479px) 92vw, (max-width: 767px) 100vw, (max-width: 991px) 96vw, 982px" class="platform-image-source"></div>
               <div class="platform-text-block">
                 <div class="platform-name">Matrix (via Riot.im)</div>


### PR DESCRIPTION
There are different ways to reach the Decred chat rooms on Matrix. This commit makes sure that users register on the Decred homeserver instead of the Matrix homeserver. This has several advantages: 1) you have a nice decred.org in your user ID. 2) if the Decred homeserver gets disconnected from other homeservers, its users will still be able to communicate with one another. 3) easier to find other Decred rooms and users. 4) you won't route through yet another machine controlled by a 3rd party.