### PR TITLE
Add security headers

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -14,6 +14,12 @@ server {
     #access_log  /var/log/nginx/host.access.log  main;
 
     server_tokens off;
+    #Security Headers
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options DENY always;  
+    add_header X-XSS-Protection "1; mode=block" always; 
+    add_header Referrer-Policy "no-referrer" always;
+    
 
     location / {
         root   /usr/share/nginx/html;

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -16,7 +16,7 @@ server {
     server_tokens off;
     #Security Headers
     add_header X-Content-Type-Options "nosniff" always;
-    add_header X-Frame-Options DENY always;  
+    add_header X-Frame-Options "DENY" always;  
     add_header X-XSS-Protection "1; mode=block" always; 
     add_header Referrer-Policy "no-referrer" always;
     


### PR DESCRIPTION
Adds the following security headers. 

    add_header X-Content-Type-Options "nosniff" always;  ==> Prevents "mime" based attacks. 
    add_header X-Frame-Options DENY always;   ==> Disable iframe of the website. 
    add_header X-XSS-Protection "1; mode=block" always;  ==> Enable XSS protection. 
    add_header Referrer-Policy "no-referrer" always; ==> Disable referrer from being shared on any request. 

"always" forces these headers for all response codes.

http://nginx.org/en/docs/http/ngx_http_headers_module.html 