### PR TITLE
Fix typo in matrix page.

### DIFF
--- a/src/layouts/matrix/list.html
+++ b/src/layouts/matrix/list.html
@@ -6,7 +6,7 @@
         <div class="left-wrapper">
           <div class="slack-join-notice">
             <p>{{ T "matrix_to_register_using_the_riot" }}</p>
-            <p><a href="https://riot.im/app/#/register?hs_url=https://matrix.decred.org">Re{{ T "matrix_register_with_riot" }}</a></p>
+            <p><a href="https://riot.im/app/#/register?hs_url=https://matrix.decred.org">{{ T "matrix_register_with_riot" }}</a></p>
             <p class="slack-join-notice-highlight">{{ T "matrix_note_you_must_register_with" }}</p>
             <p>{{ T "matrix_if_you_already_have_an" }}</p>
             <p><a href="https://matrix.to/#/+decred:decred.org">{{ T "matrix_login_to_decred_homeserver" | safeHTML }}</a></p>


### PR DESCRIPTION
The link to "https://riot.im/app/#/register?hs_url=https://matrix.decred.org" had the typo "**Re**Register with Riot." , fixed that.