### PR TITLE
Remove extra @ from medium username.

### DIFF
--- a/src/data/contributors/people.yml
+++ b/src/data/contributors/people.yml
@@ -344,7 +344,7 @@
   name: "Richard Red"
   title: "Research and Strategy"
   github_id: RichardRed0x
-  medium_alias: "@richardred"
+  medium_alias: "richardred"
 -
   matrix_id: zubairzia0:decred.org
   group: strategy


### PR DESCRIPTION
Prefixing medium usernames with `@` is not required and breaks links.