### PR TITLE
Max width for quotes on /brief.

### DIFF
--- a/src/assets/css/decred-v5.css
+++ b/src/assets/css/decred-v5.css
@@ -6970,6 +6970,7 @@ html[dir="rtl"] .lang-menu {
 }
 
 .comments-box {
+  max-width: 650px;
   margin-left: -24px;
   margin-bottom: 46px;
   padding: 24px;


### PR DESCRIPTION
Closes #644 

Adding a max-width to this element doesn't entirely fix the problem, but it does fix it for all but the narrowest of desktop views. Definitely a big improvement. A proper fix will be difficult because the menu is a fixed position element, doesnt seem like its worth the effort