### PR TITLE
Add Binance to OTC exchanges.

### DIFF
--- a/src/data/exchanges/otc.yml
+++ b/src/data/exchanges/otc.yml
@@ -18,3 +18,8 @@
   url: "https://onechaincapital.com/"
   tags: ""
   logo_src: "onechaincapital.jpg"
+-
+  name: "Binance OTC"
+  url: "https://www.binance.com/en/blog/294786426278453248/Crypto-OTC-Services-Now-Available-on-Binancebinance"
+  tags: ""
+  logo_src: "binance.jpg"


### PR DESCRIPTION
Uses the existing Binance logo and [the announcement blog post](https://www.binance.com/en/blog/294786426278453248/Crypto-OTC-Services-Now-Available-on-Binancebinance) as the URL

Closes #653 