### PR TITLE
Fix Roadmap labels and dates consistency

### DIFF
--- a/src/data/roadmap.yml
+++ b/src/data/roadmap.yml
@@ -109,7 +109,7 @@
 - tags: completed
   image: "roadmap/DEXCompleted.svg"
   title: "Proposal For a Decentralized Exchange"
-  date: "Completed Q2 2018"
+  date: "Completed Q1 2019"
   description: "A proposal for a full-fledged decentralized exchange expanding on the atomicswap tools that we released in 2017. Unlike the profit-centric models common in the space, it will aim to be open, welcoming involvement from other cryptocurrencies. The project will be formalized as a Politeia proposal."
   link: "https://blog.decred.org/2018/06/05/A-New-Kind-of-DEX/"
 - tags: new

--- a/src/data/roadmap.yml
+++ b/src/data/roadmap.yml
@@ -91,13 +91,13 @@
 - tags: completed
   image: "roadmap/spvWalletSupportCompleted.svg"
   title: "SPV Wallet Support"
-  date: "Completed Q4 2018"
+  date: "Completed Q3 2018"
   description: "Instead of taking the typical wallet service approach where wallets connect to a centralized server, or using 'bloom filters' which compromise privacy, we are working on a proper SPV mechanism that uses 'compact filters' and works over the P2P network."
   link: "https://github.com/decred/dcrwallet/issues/1000"
 - tags: completed
   image: "roadmap/trezorComplete.svg"
   title: "Trezor Decrediton Integration"
-  date: "Completed Q1 2019"
+  date: "Completed Q4 2018"
   description: "Enable storing and sending of Decred using Trezor hardware wallet."
   link: "https://github.com/decred/decrediton/issues/1491"
 - tags: ongoing
@@ -109,7 +109,7 @@
 - tags: completed
   image: "roadmap/DEXCompleted.svg"
   title: "Proposal For a Decentralized Exchange"
-  date: "Completed Q3 2018"
+  date: "Completed Q2 2018"
   description: "A proposal for a full-fledged decentralized exchange expanding on the atomicswap tools that we released in 2017. Unlike the profit-centric models common in the space, it will aim to be open, welcoming involvement from other cryptocurrencies. The project will be formalized as a Politeia proposal."
   link: "https://blog.decred.org/2018/06/05/A-New-Kind-of-DEX/"
 - tags: new
@@ -127,7 +127,7 @@
 - tags: completed
   image: "roadmap/decreditonIntegrCompleted.svg"
   title: "Decrediton Politeia Integration"
-  date: "Completed Q4 2018"
+  date: "Completed Q3 2018"
   description: "Enabling stakeholders to view proposals and cast votes directly from Decrediton wallet is a big step towards effective governance and seamless stakeholder participation."
   link: "https://github.com/decred/decrediton/issues/1244"
 - tags: completed

--- a/src/data/roadmap.yml
+++ b/src/data/roadmap.yml
@@ -91,14 +91,15 @@
 - tags: completed
   image: "roadmap/spvWalletSupportCompleted.svg"
   title: "SPV Wallet Support"
-  date: "Added Q1 2018"
+  date: "Completed Q4 2018"
   description: "Instead of taking the typical wallet service approach where wallets connect to a centralized server, or using 'bloom filters' which compromise privacy, we are working on a proper SPV mechanism that uses 'compact filters' and works over the P2P network."
   link: "https://github.com/decred/dcrwallet/issues/1000"
 - tags: completed
   image: "roadmap/trezorComplete.svg"
   title: "Trezor Decrediton Integration"
-  date: "Added Q4 2017"
+  date: "Completed Q1 2019"
   description: "Enable storing and sending of Decred using Trezor hardware wallet."
+  link: "https://github.com/decred/decrediton/issues/1491"
 - tags: ongoing
   image: "roadmap/DAEActive.svg"
   title: "Decentralized Autonomous Entities"
@@ -108,7 +109,7 @@
 - tags: completed
   image: "roadmap/DEXCompleted.svg"
   title: "Proposal For a Decentralized Exchange"
-  date: "Added Q1 2018"
+  date: "Completed Q3 2018"
   description: "A proposal for a full-fledged decentralized exchange expanding on the atomicswap tools that we released in 2017. Unlike the profit-centric models common in the space, it will aim to be open, welcoming involvement from other cryptocurrencies. The project will be formalized as a Politeia proposal."
   link: "https://blog.decred.org/2018/06/05/A-New-Kind-of-DEX/"
 - tags: new
@@ -126,7 +127,7 @@
 - tags: completed
   image: "roadmap/decreditonIntegrCompleted.svg"
   title: "Decrediton Politeia Integration"
-  date: "Added Q1 2018"
+  date: "Completed Q4 2018"
   description: "Enabling stakeholders to view proposals and cast votes directly from Decrediton wallet is a big step towards effective governance and seamless stakeholder participation."
   link: "https://github.com/decred/decrediton/issues/1244"
 - tags: completed


### PR DESCRIPTION
Fixes #663

Renamed a few ‘Added on’ labels with ‘Completed on’ on completed section in Roadmap page and update the dates. I found the completion dates mostly from GitHub merges to master record please confirm them.

I used the fiscal year measurements in which Q1 is October, November, and December, Q2 is January, February, and March, Q3 is April, May, and June, and Q4 is July, August, and September  as that seemed to be used for the other dates. 



![Screen Shot 2019-05-28 at 9 17 08 AM](https://user-images.githubusercontent.com/5521110/58494441-f70d5880-8129-11e9-9d5e-b7ff80ca65ff.png)
