### PR TITLE
Flicker fix on Press page

### DIFF
--- a/src/layouts/press/list.html
+++ b/src/layouts/press/list.html
@@ -24,4 +24,10 @@
             </div>
         </div>
     </div>
+
+    <!-- fix z-index bug (issue #625) -->
+    <script>
+      var below = document.getElementsByClassName("below");
+      below[0].style["zIndex"] = "initial";
+    </script>
 {{end}}


### PR DESCRIPTION
Changing z-index on 'below' class messed with other pages. This commit fixes the flickering like previous #665 however this solution applies update to that page only. 
Updates #669 and #665  