### PR TITLE
Update people.yml

### DIFF
--- a/src/data/contributors/people.yml
+++ b/src/data/contributors/people.yml
@@ -10,7 +10,7 @@
   medium_alias: macsleven
 -
   matrix_id: ay-p:decred.org
-  twitter_alias: "_alyp"
+  twitter_alias: "_alyp_"
   company_id: c0
   group: development
   avatar_image: "team_1.svg"


### PR DESCRIPTION
Fixed Alex Yocom-Piatt Twitter handle to his actual handle and not someone else.