### PR TITLE
Update Slack invite

### DIFF
--- a/src/data/community/channels.yml
+++ b/src/data/community/channels.yml
@@ -7,7 +7,7 @@
   img_src: "dcr-community-platforms-discord.png"
   name: Discord
 -
-  url: "https://slack.decred.org"
+  url: "https://join.slack.com/t/decred/shared_invite/enQtNTE4MDM1NzAzODEzLWFiYzgwN2YzYTQyNWQxOTg2NjEwNGU5YTI4YmZiNTI5Mzk2Y2E1N2QxNWEwOWVmYmYzZWY3MWNjNTJlYTgyZDQ"
   img_src: "dcr-community-platforms-slack.png"
   name: Slack
 -


### PR DESCRIPTION
Invite URL that slack.decred.org was pointing to had expired. Replaced it with a new link.