### PR TITLE
Don't pluralize page titles

### DIFF
--- a/src/config.yml
+++ b/src/config.yml
@@ -3,6 +3,7 @@ languageCode: en-us
 title: Decred
 defaultContentLanguage: en
 defaultContentLanguageInSubdir: false
+pluralizelisttitles: false
 
 params:
     social_media_links:


### PR DESCRIPTION
This prevents page titles from being pluralized automatically by Hugo. Previously we were seeing page titles like `Decred - Sustainabilities` rather than `Decred - Sustainable`.