### PR TITLE
Keep selected language when returning to homepage

### DIFF
--- a/src/layouts/_default/list.html
+++ b/src/layouts/_default/list.html
@@ -7,7 +7,7 @@
     {{ if .IsHome }}
     {{ $download_links := where (index .Site.Data.wallets.links "decrediton") "is_direct_download" true }}
     <div class="fronta landing video-header">
-        <div class="_960 subpage-header"><a href="{{ .Site.BaseURL }}" class="subpage-logo-dark w-inline-block"></a></div>
+        <div class="_960 subpage-header"><a href="{{ "/" | relLangURL }}" class="subpage-logo-dark w-inline-block"></a></div>
         <div class="_960 subpage-header">
             <div class="landing-title">{{ T "landing_opener" }}</div>
             <div class="d-flex"> 

--- a/src/layouts/partials/subpage-content-header.html
+++ b/src/layouts/partials/subpage-content-header.html
@@ -4,7 +4,7 @@
         <source src="{{ .Site.BaseURL }}/videos/headers/contributors/video.webm" type="video/webm">
         <source src="{{ .Site.BaseURL }}/videos/headers/contributors/video.ogv" type="video/ogg">
     </video>
-    <div class="_960 subpage-header"><a href="{{ .Site.BaseURL }}" class="subpage-logo w-inline-block"></a></div>
+    <div class="_960 subpage-header"><a href="{{ "/" | relLangURL }}" class="subpage-logo w-inline-block"></a></div>
     <div class="_960 subpage-header">
         <div class="subpage-title" translate>{{ .Title }}</div>
     </div>


### PR DESCRIPTION
When a language has been selected (eg visit https://decred.org/de/security/) if you click on the top left decred logo to go back to the homepage, the language selection is reset to english. This PR enables keeping the selected language so it doesnt need to be chosen again from the dropdown menu