### PR TITLE
Use stable alpine rather than edge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # builder image
-FROM alpine:edge
+FROM alpine:latest
 
 ARG HUGO_BASEURL
 ENV HUGO_BASEURL ${HUGO_BASEURL:-https://decred.org}


### PR DESCRIPTION
Use latest alpine image rather than edge. We don't need the bleeding edge release which may include untested or broken functionality