### PR TITLE
Reinstate missing page headers.

### DIFF
--- a/src/layouts/_default/baseof.html
+++ b/src/layouts/_default/baseof.html
@@ -3,12 +3,15 @@
 
     <head>
         <meta charset="utf-8">
-      
-        {{ block "page-title" . }}
+
+        {{ if .IsHome }}
           <title>{{ T "title" }}</title>
           <meta content="{{ T "title" }}" property="og:title">
+        {{ else }}
+          <title>Decred - {{ block "page-title" . }}{{ end }}</title>
+          <meta content="Decred - {{ block "page-title" . }}{{ end }}" property="og:title">
         {{ end }}
-      
+
         <meta content='{{ T "description" }}' name="description">
       
         <meta content="{{ T "description" }}" property="og:description">
@@ -118,7 +121,7 @@
                         <a href="{{ .Site.BaseURL | absLangURL  }}" class="subpage-logo w-inline-block"></a>
                     </div>
                     <div class="_960 subpage-header">
-                        <div class="subpage-title">{{ T .Title }}</div>
+                        <div class="subpage-title">{{ block "page-title" . }}{{ end }}</div>
                     </div>
                 </div>
             {{ end }}

--- a/src/layouts/adaptability/list.html
+++ b/src/layouts/adaptability/list.html
@@ -1,6 +1,5 @@
 {{ define "page-title" }}
-    <title>Decred - {{ T "nav_adaptability" }}</title>
-    <meta content="Decred - {{ T "nav_adaptability" }}" property="og:title">
+    {{ T "nav_adaptability" }}
 {{ end }}
 
 {{ define "main" }}

--- a/src/layouts/brand/list.html
+++ b/src/layouts/brand/list.html
@@ -1,6 +1,5 @@
 {{ define "page-title" }}
-    <title>Decred - {{ T "nav_brand_resources" }}</title>
-    <meta content="Decred - {{ T "nav_brand_resources" }}" property="og:title">
+    {{ T "nav_brand_resources" }}
 {{ end }}
 
 {{ define "content-top" }}

--- a/src/layouts/brief/list.html
+++ b/src/layouts/brief/list.html
@@ -1,6 +1,5 @@
 {{ define "page-title" }}
-    <title>Decred - {{ T "nav_business_brief" }}</title>
-    <meta content="Decred - {{ T "nav_business_brief" }}" property="og:title">
+    {{ T "nav_business_brief" }}
 {{ end }}
 
 {{ define "content-top" }}

--- a/src/layouts/community/list.html
+++ b/src/layouts/community/list.html
@@ -1,6 +1,5 @@
 {{ define "page-title" }}
-    <title>Decred - {{ T "nav_community" }}</title>
-    <meta content="Decred - {{ T "nav_community" }}" property="og:title">
+    {{ T "nav_community" }}
 {{ end }}
 
 {{ define "main" }}

--- a/src/layouts/contributors/list.html
+++ b/src/layouts/contributors/list.html
@@ -1,6 +1,5 @@
 {{ define "page-title" }}
-    <title>Decred - {{ T "nav_contributors" }}</title>
-    <meta content="Decred - {{ T "nav_contributors" }}" property="og:title">
+    {{ T "nav_contributors" }}
 {{ end }}
 
 

--- a/src/layouts/exchanges/list.html
+++ b/src/layouts/exchanges/list.html
@@ -1,6 +1,5 @@
 {{ define "page-title" }}
-    <title>Decred - {{ T "nav_exchanges" }}</title>
-    <meta content="Decred - {{ T "nav_exchanges" }}" property="og:title">
+    {{ T "nav_exchanges" }}
 {{ end }}
 
 {{ define "content-top" }}

--- a/src/layouts/history/list.html
+++ b/src/layouts/history/list.html
@@ -1,6 +1,5 @@
 {{ define "page-title" }}
-    <title>Decred - {{ T "nav_pastfuture" }}</title>
-    <meta content="Decred - {{ T "nav_pastfuture" }}" property="og:title">
+    {{ T "nav_pastfuture" }}
 {{ end }}
 
 {{ define "main" }}

--- a/src/layouts/press/list.html
+++ b/src/layouts/press/list.html
@@ -1,6 +1,5 @@
 {{ define "page-title" }}
-    <title>Decred - {{ T "nav_press" }}</title>
-    <meta content="Decred - {{ T "nav_press" }}" property="og:title">
+    {{ T "nav_press" }}
 {{ end }}
 
 {{ define "main" }}

--- a/src/layouts/roadmap/list.html
+++ b/src/layouts/roadmap/list.html
@@ -1,6 +1,5 @@
 {{ define "page-title" }}
-    <title>Decred - {{ T "nav_roadmap" }}</title>
-    <meta content="Decred - {{ T "nav_roadmap" }}" property="og:title">
+    {{ T "nav_roadmap" }}
 {{ end }}
 
 {{ define "main" }}

--- a/src/layouts/security/list.html
+++ b/src/layouts/security/list.html
@@ -1,6 +1,5 @@
 {{ define "page-title" }}
-    <title>Decred - {{ T "nav_security" }}</title>
-    <meta content="Decred - {{ T "nav_security" }}" property="og:title">
+    {{ T "nav_security" }}
 {{ end }}
 
 {{ define "main" }}

--- a/src/layouts/sustainability/list.html
+++ b/src/layouts/sustainability/list.html
@@ -1,6 +1,5 @@
 {{ define "page-title" }}
-    <title>Decred - {{ T "nav_sustainability" }}</title>
-    <meta content="Decred - {{ T "nav_sustainability" }}" property="og:title">
+    {{ T "nav_sustainability" }}
 {{ end }}
 
 {{ define "main" }}

--- a/src/layouts/vsp/list.html
+++ b/src/layouts/vsp/list.html
@@ -1,6 +1,5 @@
 {{ define "page-title" }}
-    <title>Decred - {{ T "nav_vsp" }}</title>
-    <meta content="Decred - {{ T "nav_vsp" }}" property="og:title">
+    {{ T "nav_vsp" }}
 {{ end }}
 
 {{ define "main" }}

--- a/src/layouts/wallets/list.html
+++ b/src/layouts/wallets/list.html
@@ -1,6 +1,5 @@
 {{ define "page-title" }}
-    <title>Decred - {{ T "nav_downloads" }}</title>
-    <meta content="Decred - {{ T "nav_downloads" }}" property="og:title">
+    {{ T "nav_downloads" }}
 {{ end }}
 
 {{ define "main" }}


### PR DESCRIPTION
We have been missing page headers for a while (I think since the new design). This adds them back, and also adds the ability for them to be translated.