### PR TITLE
nojs improvements

### DIFF
--- a/src/assets/css/decred-v5.css
+++ b/src/assets/css/decred-v5.css
@@ -6034,18 +6034,19 @@ p.text-block-11 {
   }
 }
 
-.subpage__toggle a {
+.subpage__toggle label {
   color: #596D81;
   padding: 10px 30px;
   display: inline-block;
   margin-right: -1px;
 }
 
-.subpage__toggle a:hover {
+.subpage__toggle label:hover {
   cursor: pointer;
 }
 
-.subpage__toggle a.active {
+#releases:checked ~ div label[for='releases'],
+#coverage:checked ~ div label[for='coverage'] {
   background: #E7EAED;
   color: #091440;
 }
@@ -6058,7 +6059,8 @@ p.text-block-11 {
   top: 0;
 }
 
-.toggleable .subpage-content.active {
+#releases:checked ~ div .press__releases,
+#coverage:checked ~ div .press__coverage {
   opacity: 1;
   visibility: visible;
   position: relative;

--- a/src/assets/css/decred-v5.css
+++ b/src/assets/css/decred-v5.css
@@ -3135,7 +3135,6 @@ p.text-block-11 {
   position: relative;
   margin-right: 24px;
   margin-bottom: 36px;
-  cursor: pointer;
 }
 
 .history-principles hr {
@@ -3150,16 +3149,26 @@ p.text-block-11 {
   color: #e9f8fe;
 }
 
-.history-principles.active {
+.history-principles label {
+  position:absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+  cursor: pointer;
+}
+
+#principle1:checked ~ div label[for='principle1'] ~ p,
+#principle2:checked ~ div label[for='principle2'] ~ p,
+#principle3:checked ~ div label[for='principle3'] ~ p,
+#principle4:checked ~ div label[for='principle4'] ~ p,
+#principle5:checked ~ div label[for='principle5'] ~ p,
+#principle6:checked ~ div label[for='principle6'] ~ p {
   color: #e9f8fe;
 }
 
-.history-select {
+.history-principles {
   color: #091440; 
-}
-
-.history-select.active {
-  color: #e9f8fe;
 }
 
 .history-slide-icon {
@@ -3182,7 +3191,12 @@ p.text-block-11 {
   transition: all 300ms ease;
 }
 
-.history-slide.active {
+#principle1:checked ~ div .principle1,
+#principle2:checked ~ div .principle2,
+#principle3:checked ~ div .principle3,
+#principle4:checked ~ div .principle4,
+#principle5:checked ~ div .principle5,
+#principle6:checked ~ div .principle6 {
   position: relative;
   height: auto;
   max-height: 500px;

--- a/src/assets/js/main-ex.js
+++ b/src/assets/js/main-ex.js
@@ -83,6 +83,8 @@ $(function(){
     // Code below here is implementing the nav menu for /brief
     //
     
+    $('.basic-sticky').show();
+
     $('#hide-all').click(function(){
         $('#x-menu').toggle(500);
         $('#hide-all').hide();

--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -1,13 +1,5 @@
 $(document).ready(function () {
 
-	$('.subpage__toggle a').on('click', function() {
-		$('.subpage__toggle a').removeClass(active);
-		$(this).addClass('active');
-		var toggle = $(this).attr("data-toggle");
-		$('.subpage-content-section div').removeClass('active');
-		$('.subpage-content-section').find('div.'+ toggle).addClass('active');
-	});
-
 	$('.press__releases-item').on('click', function() {
 		$a = $(this);
 

--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -36,15 +36,9 @@ $(document).ready(function () {
 		active = 'active',
 
 		// first view
-		logo = $('.logo'),
-		slogan = $('.slogan'),
 		playButton = $('.play-modal'),
 		mobilePlayButton = $('.mobile-play-button'),
 		videoModal = $('.video-modal'),
-
-		// principles section
-		principlesSelect = $('.history-select'),
-		principlesSlide = $('.history-slide'),
 
 		// team subpage
 		teamFilterButton = $('.team-filter-button'),
@@ -157,15 +151,6 @@ $(document).ready(function () {
 		videoModal.removeClass('active');
 		});
 	}
-
-	// principles section
-	principlesSelect.eq(0).addClass('active');
-	principlesSlide.eq(0).addClass('active');
-	principlesSelect.click( function() {
-		principlesSelect.add(principlesSlide).removeClass('active');
-		principlesSlide.eq($(this).index()).addClass('active');
-		$(this).toggleClass('active');
-	});
 
 	// get download_count from github
 	$.getJSON(APIdc, function(data) {

--- a/src/layouts/brief/list.html
+++ b/src/layouts/brief/list.html
@@ -21,7 +21,7 @@
                 </div>
             </div>
 
-            <div class="outline basic-sticky">
+            <div class="outline basic-sticky" style="display: none;">
                 <div class="text-block-8">Outline
                     <div id="up-down" style="display: none;">
                         <a class="prev-section section-target"></a>

--- a/src/layouts/partials/history/principles.html
+++ b/src/layouts/partials/history/principles.html
@@ -2,45 +2,65 @@
     <div class="_960">
         <p class="text-block-7">{{ T "history_principles_headline" }}</p>
         <div class="row">
+
+            <input class="w-hidden" type="radio" id="principle1" name="subpage_toggler" checked />
+            <input class="w-hidden" type="radio" id="principle2" name="subpage_toggler" />
+            <input class="w-hidden" type="radio" id="principle3" name="subpage_toggler" />
+            <input class="w-hidden" type="radio" id="principle4" name="subpage_toggler" />
+            <input class="w-hidden" type="radio" id="principle5" name="subpage_toggler" />
+            <input class="w-hidden" type="radio" id="principle6" name="subpage_toggler" />
+            
             <div class="col-8">
                 <div class="row">
-                    <div class="col-6x history-select">
+                    <div class="col-6x">
                         <div class="history-principles">
+                            <label for="principle1">
+                            </label>
                             <p class="text-size--10">01</p>
                             <hr>
                             <p class="text-size--12">{{ T "history_principles_01" }}</p>
                         </div>
                     </div>
-                    <div class="col-6x history-select">
+                    <div class="col-6x">
                         <div class="history-principles">
+                            <label for="principle2">
+                            </label>
                             <p class="text-size--10">02</p>
                             <hr>
                             <p class="text-size--12">{{ T "history_principles_02" }}</p>
                         </div>
                     </div>
-                    <div class="col-6x history-select">
+                    <div class="col-6x">
                         <div class="history-principles">
+                            <label for="principle3">
+                            </label>
                             <p class="text-size--10">03</p>
                             <hr>
                             <p class="text-size--12">{{ T "history_principles_03" }}</p>
                         </div>
                     </div>
-                    <div class="col-6x history-select">
+                    <div class="col-6x">
                         <div class="history-principles">
+                            <label for="principle4">
+                            </label>
                             <p class="text-size--10">04</p>
                             <hr>
                             <p class="text-size--12">{{ T "history_principles_04" }}</p>
                         </div>
                     </div>
-                    <div class="col-6x history-select">
+                    <div class="col-6x">
                         <div class="history-principles">
+                            <label for="principle5">
+                            </label>
                             <p class="text-size--10">05</p>
                             <hr>
                             <p class="text-size--12">{{ T "history_principles_05" }}</p>
                         </div>
                     </div>
-                    <div class="col-6x history-select">
+                    <div class="col-6x">
                         <div class="history-principles">
+                            <label for="principle6">
+                            </label>
                             <p class="text-size--10">06</p>
                             <hr>
                             <p class="text-size--12">{{ T "history_principles_06" }}</p>
@@ -50,27 +70,27 @@
             </div>
             <div class="col-4x">
                 <div class="history-slides-nest">
-                <div class="active history-slide">
+                <div class="history-slide principle1">
                     <img src="{{ .Site.BaseURL }}/images/principles_opensourceSoftware.svg" class="history-slide-icon" alt="">
                     <p class="text-size--22">{{ T "home_principles_free"  | safeHTML }}</p>
                 </div>
-                <div class="history-slide">
+                <div class="history-slide principle2">
                     <img src="{{ .Site.BaseURL }}/images/principles_freespeech.svg" class="history-slide-icon" alt="">
                     <p class="text-size--22">{{ T "home_principles_everyone" | safeHTML  }}</p>
                 </div>
-                <div class="history-slide">
+                <div class="history-slide principle3">
                     <img src="{{ .Site.BaseURL }}/images/principles_multistakeholderInclusivity.svg" class="history-slide-icon" alt="">
                     <p class="text-size--22">{{ T "home_principles_inclusivity" | safeHTML  }}</p>
                 </div>
-                <div class="history-slide">
+                <div class="history-slide principle4">
                     <img src="{{ .Site.BaseURL }}/images/principles_privacySecurity.svg" class="history-slide-icon" alt="">
                     <p class="text-size--22">{{ T "home_principles_privacy" | safeHTML  }}</p>
                 </div>
-                <div class="history-slide">
+                <div class="history-slide principle5">
                     <img src="{{ .Site.BaseURL }}/images/principles_fixedfiniteSupply.svg" class="history-slide-icon" alt="">
                     <p class="text-size--22">{{ T "home_principles_supply" | safeHTML  }}</p>
                 </div>
-                <div class="history-slide">
+                <div class="history-slide principle6">
                     <img src="{{ .Site.BaseURL }}/images/principles_universalFungibility.svg" class="history-slide-icon" alt="">
                     <p class="text-size--22">{{ T "home_principles_fungibility" | safeHTML }}</p>
                 </div>

--- a/src/layouts/press/list.html
+++ b/src/layouts/press/list.html
@@ -3,23 +3,26 @@
 {{ end }}
 
 {{ define "main" }}
+    <input class="w-hidden" type="radio" id="coverage" name="subpage_toggler" checked />
+    <input class="w-hidden" type="radio" id="releases" name="subpage_toggler" />
+    
     <div class="full-width">
         <div class="_960">
             <div class="subpage-description">{{ T "press_description" | safeHTML }}</div>
             <div class="subpage__toggle">
-                <a data-toggle="press__coverage" class="active">{{ T "press_coverage" }}</a>
-                <a data-toggle="press__releases">{{ T "press_releases" }}</a>
+                <label for="coverage">{{ T "press_coverage" }}</label>
+                <label for="releases">{{ T "press_releases" }}</label>
             </div>
         </div>
     </div>
-
+    
     <div class="full-width press__wrapper">
         <div class="_960">
             <div class="subpage-content-section toggleable">
-                <div class="press press__coverage subpage-content w-clearfix active">
+                <div class="press press__coverage subpage-content w-clearfix">
                     {{ partial "press/coverage-list" .Site.Data.press.coverage }}
                 </div>
-
+                
                 <div class="press press__releases subpage-content w-clearfix">
                     {{ partial "press/release-list" . }}
                 </div>


### PR DESCRIPTION
- Principles on the /history page can be viewed without js
- Nav menu on the /brief page is now hidden without js, rather than displaying a non-functional menu
- Both coverage and releases can be viewed without js on the /press page