### PR TITLE
Remove quotes from generic font-family names

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:latest
 
 ARG HUGO_BASEURL
 ENV HUGO_BASEURL ${HUGO_BASEURL:-https://decred.org}
-ENV HUGO_VERSION 0.69.2
+ENV HUGO_VERSION 0.72.0
 
 LABEL description="gohugo build"
 LABEL version="1.0"
@@ -23,7 +23,7 @@ COPY ./ /root/
 RUN bin/build-hugo.sh
 
 # final image
-FROM nginx:1.16
+FROM nginx:1.18
 
 LABEL description="dcrweb server"
 LABEL version="1.0"

--- a/src/assets/css/fonts.css
+++ b/src/assets/css/fonts.css
@@ -53,11 +53,9 @@
 }
 
 html, body {
-    /* use !important to prevent issues with browser extensions that change fonts */
-    font-family: "dcrweb", "Verdana", "sans-serif" !important;
+    font-family: "dcrweb", "Verdana", sans-serif;
 }
 
 pre, code {
-    /* use !important to prevent issues with browser extensions that change fonts */
-    font-family: "dcrweb-code", "Courier New", "monospace" !important;
+    font-family: "dcrweb-code", "Courier New", monospace;
 }


### PR DESCRIPTION
Discovered in decred/dcrdocs#1103, generic font-family names should not have quotes: https://developer.mozilla.org/en-US/docs/Web/CSS/font-family

Also taken the opportunity to update build deps.