### PR TITLE
Fix some nav menu issues

### DIFF
--- a/src/layouts/partials/navbar.html
+++ b/src/layouts/partials/navbar.html
@@ -24,11 +24,11 @@
                                 <li><a href="#" class="navigation-link">{{ T "nav_getstarted" }} →</a>
                                     <ul>
                                         <li><a href="{{ "wallets/" | relLangURL }}" class="navigation-link">{{ T "nav_downloads" }}</a></li>
-                                        <li><a href="{{ "exchanges/" | relLangURL }}" class="navigation-link active">{{ T "nav_exchanges" }}</a></li>
-                                        <li><a href="{{ "vsp/" | relLangURL }}" class="navigation-link external">{{ T "nav_stakingvoting" }}</a></li>
+                                        <li><a href="{{ "exchanges/" | relLangURL }}" class="navigation-link">{{ T "nav_exchanges" }}</a></li>
+                                        <li><a href="{{ "vsp/" | relLangURL }}" class="navigation-link">{{ T "nav_stakingvoting" }}</a></li>
                                         <li><a href="https://proposals.decred.org" target="_blank" rel="noopener noreferrer" class="navigation-link external">{{T "nav_politeia" }}</a></li>
                                         <li><a href="https://dcrdata.decred.org" target="_blank" rel="noopener noreferrer" class="navigation-link external">{{T "nav_networkstats" }}</a></li>
-                                        <li><a href="https://bounty.decred.org/" target="_blank" rel="noopener noreferrer" class="navigation-link">{{ T "nav_bugbounty" }}</a></li>
+                                        <li><a href="https://bounty.decred.org/" target="_blank" rel="noopener noreferrer" class="navigation-link external">{{ T "nav_bugbounty" }}</a></li>
                                         <li><a href="{{ "community/" | relLangURL }}" class="navigation-link">{{ T "nav_community" }}</a></li>
                                     </ul>
                                 </li>
@@ -36,7 +36,7 @@
                                     <ul>
                                         <li><a href="https://docs.decred.org/" target="_blank" rel="noopener noreferrer" class="navigation-link external">{{ T "nav_documentation" }}</a></li>
                                         <li><a href="{{ "contributors/" | relLangURL }}" class="navigation-link">{{ T "nav_contributors" }}</a></li>
-                                        <li><a href="https://github.com/decred" target="_blank" rel="noopener noreferrer" class="navigation-link">{{ T "nav_development" }}</a></li>
+                                        <li><a href="https://github.com/decred" target="_blank" rel="noopener noreferrer" class="navigation-link external">{{ T "nav_development" }}</a></li>
                                         <li><a href="{{ "brief/" | relLangURL }}" class="navigation-link">{{ T "nav_business_brief" }}</a></li>
                                         <li><a href="{{ "brand/" | relLangURL }}" class="navigation-link">{{ T "nav_brand_resources" }}</a></li>
                                     </ul>

--- a/transifex_catalogs/en.json
+++ b/transifex_catalogs/en.json
@@ -29,6 +29,7 @@
   "nav_documentation": "Documentation",
   "nav_community": "Community",
   "nav_contributors": "Contributors",
+  "nav_development": "Development",
   "nav_exchanges": "Exchanges",
   "nav_press": "Press",
   "nav_intro": "Home",


### PR DESCRIPTION
- Remove ineffective `.active` from Exchanges link
- `/vsp` is not an external link
- `bounty.decred.org` and `github.org` are external links
- Missing string in translation file resulted in Development link not showing

