### PR TITLE
Ensure all nav menu items are visible

### DIFF
--- a/src/assets/css/decred-v5.css
+++ b/src/assets/css/decred-v5.css
@@ -1322,17 +1322,9 @@ ul, li, nav {
 }
 
 #menu { 
-  overflow-y: scroll;
-  overflow-x: hidden;
   position: relative; 
   z-index: 2; 
   padding-bottom: 30px;
-}
-
-@media (min-width: 768px) {
-  #menu {
-    overflow: hidden !important;
-  }
 }
 
 .parent-menu { 


### PR DESCRIPTION
I can't find any valid purpose for these `overflow` rules, and they are preventing the entire nav menu from being displayed on desktop.

For an example, open the "Get Started" sub-menu and "Community" is not visible at the bottom (it should be below "Bug Bounty")