### PR TITLE
Use latest Hugo and html-validator-cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:latest
 
 ARG HUGO_BASEURL
 ENV HUGO_BASEURL ${HUGO_BASEURL:-https://decred.org}
-ENV HUGO_VERSION 0.72.0
+ENV HUGO_VERSION 0.75.1
 
 LABEL description="gohugo build"
 LABEL version="1.0"

--- a/test/package.json
+++ b/test/package.json
@@ -7,6 +7,6 @@
     "author": "Peter Banik <peter@froggle.org>",
     "license": "ISC",
     "devDependencies": {
-        "html-validator-cli": "^6.0.2"
+        "html-validator-cli": "^7.0.1"
     }
 }


### PR DESCRIPTION
Some reasonably big changes to Hugo in the last couple of versions - just making sure we don't fall behind too much

Also ensure that the same version of `html-validator-cli` is used in both `package.json` and `test/package.json` (only one was updated in #912)