### PR TITLE
Update to release 1.7.0.

### DIFF
--- a/src/assets/css/decred-v5.css
+++ b/src/assets/css/decred-v5.css
@@ -5816,6 +5816,9 @@ p.text-block-11 {
 .macdl {
   display: none;
 }
+.macm1dl {
+  display: none;
+}
 .linuxdl {
   display: none;
 }

--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -171,6 +171,10 @@ $(document).ready(function () {
 	}
 
 	if (platform.os.family == "OS X") {
+
+		// If we detect OS X, we can't know if the user will want an amd or arm
+		// build. Just show the amd64 link which will work on both platforms.
+
 		$(".macdl").show();
 		$(".alldl").hide();
 

--- a/src/data/wallets/apps.yml
+++ b/src/data/wallets/apps.yml
@@ -16,7 +16,7 @@
       id: trezor
       links:
         - title: Decrediton
-          url: https://decred.org/release/#downloads
+          url: https://decred.org/wallets/#decrediton
         - title: Exodus
           url: https://www.exodus.io/decred-wallet
     - name: Ledger Live

--- a/src/data/wallets/current_release.yml
+++ b/src/data/wallets/current_release.yml
@@ -1,2 +1,2 @@
-current_version: v1.6.3
+current_version: v1.7.0
 release_url_base: https://github.com/decred/decred-release/releases/tag/

--- a/src/data/wallets/links.yml
+++ b/src/data/wallets/links.yml
@@ -2,25 +2,31 @@ decrediton:
     - title: macOS
       platform: macdl
       id: decreditonmac
-      url: https://github.com/decred/decred-binaries/releases/download/v1.6.3/decrediton-v1.6.3.dmg
+      url: https://github.com/decred/decred-binaries/releases/download/v1.7.0/decrediton-amd64-v1.7.0.dmg
+      is_direct_download: true
+
+    - title: macOS (M1)
+      platform: macm1dl
+      id: decreditonmacm1
+      url: https://github.com/decred/decred-binaries/releases/download/v1.7.0/decrediton-arm64-v1.7.0.dmg
       is_direct_download: true
 
     - title: Linux
       platform: linuxdl
       id: decreditonlinux
-      url: https://github.com/decred/decred-binaries/releases/download/v1.6.3/decrediton-v1.6.3.AppImage
+      url: https://github.com/decred/decred-binaries/releases/download/v1.7.0/decrediton-v1.7.0.AppImage
       is_direct_download: true
 
     - title: Windows
       platform: windl
       id: decreditonwindows
-      url: https://github.com/decred/decred-binaries/releases/download/v1.6.3/decrediton-v1.6.3.exe
+      url: https://github.com/decred/decred-binaries/releases/download/v1.7.0/decrediton-v1.7.0.exe
       is_direct_download: true
 
     - title: Release notes
-      url: https://github.com/decred/decred-binaries/blob/master/release-notes.md#decrediton-v163
+      url: https://github.com/decred/decred-binaries/blob/master/release-notes.md#decrediton-v170
 
-release_page:
+release_page_1_6:
   mac:
     url: https://github.com/decred/decred-binaries/releases/download/v1.6.3/decrediton-v1.6.3.dmg
   win64:
@@ -40,6 +46,6 @@ mobilewallets:
 
 commandline:
     - title: View on GitHub
-      url: https://github.com/decred/decred-release/releases/tag/v1.6.3
+      url: https://github.com/decred/decred-release/releases/tag/v1.7.0
     - title: Release notes
-      url: https://github.com/decred/decred-binaries/blob/master/release-notes.md#dcrwallet-v163
+      url: https://github.com/decred/decred-binaries/blob/master/release-notes.md#dcrwallet-v170

--- a/src/layouts/_default/list.html
+++ b/src/layouts/_default/list.html
@@ -36,12 +36,12 @@
                             New release available
                         </h1>
                         <p>
-                            Use the Lightning Network. Mix your Decred. Vote on a new consensus change. Upgrade to the 1.6 release now.
+                            Use DCRDEX inside Decrediton and vote on four new consensus changes. Upgrade to the 1.7 release now!
                         </p>
                     </div>
                     <div>
-                        <a class="button" href="{{ "/release/" | relLangURL }}">
-                            Find&nbsp;out&nbsp;more
+                        <a class="button" href="{{ "/wallets/" | relLangURL }}">
+                            Download&nbsp;Now
                         </a>
                     </div>
                 </div>

--- a/src/layouts/partials/footer.html
+++ b/src/layouts/partials/footer.html
@@ -22,7 +22,7 @@
             <div class="footerblockstats footerrowscolumn1 w-clearfix w-col w-col-2 w-col-medium-2">
                 <div class="footerblockstatsrow w-clearfix">
                     {{ with $current_release }}
-                        <a id="footerRelease" class="backgroundturquoise borderradius4 dropshadow footerblockstatslink" href="{{ .release_url_base }}/{{ .current_version }}" target="_blank" rel="noopener noreferrer">{{ .current_version }}</a>
+                        <a id="footerRelease" class="backgroundturquoise borderradius4 dropshadow footerblockstatslink" href="{{ .release_url_base }}{{ .current_version }}" target="_blank" rel="noopener noreferrer">{{ .current_version }}</a>
                     {{ end }}
                     <div class="footerblockstatsname">{{ T "general_release_stable" }}</div>
                 </div>

--- a/src/layouts/release/list.html
+++ b/src/layouts/release/list.html
@@ -291,7 +291,7 @@
 
             <div class="downloads-container isRow">
 
-                {{ $download_links := .Site.Data.wallets.links.release_page }}
+                {{ $download_links := .Site.Data.wallets.links.release_page_1_6 }}
 
                 <div class="download">
                     {{ $win := resources.Get "/images/release/win.svg" }}


### PR DESCRIPTION
- The `/release` page is still focused on 1.6, so references to it are now removed.
- When OS X platform is detected, download links on the home page are amd64 builds. Users must manually click through to the `/wallets` page and select M1 if they want the arm64 build.

Preview of how M1 mac links are shown.

![Screenshot from 2022-01-24 18-09-23](https://user-images.githubusercontent.com/6762864/150839754-894e7e42-9666-4991-bd0b-c43defac01f8.png)
