### PR TITLE
Terminate dev scripts on error.

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Requires docker 17.05 or higher
 
+set -e
+
 echo ""
 echo "================================="
 echo "  Building dcrweb docker image   "

--- a/bin/watch.sh
+++ b/bin/watch.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 bin/i18n-convert-transifex-hugo.sh
 
 # Remove old hugo output before building


### PR DESCRIPTION
`set -e` will ensure these scripts terminate upon hitting an error, rather than continuing and giving the impression that nothing is wrong.