### PR TITLE
Redirects for moved/deleted pages.

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -138,22 +138,32 @@ server {
     gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss image/svg+xml text/javascript;
 
     # Redirection for dcrweb pages which no longer exist.
-    rewrite ^/stakepools/?$      $scheme://$http_host/vsp/                          permanent;
-    rewrite ^/downloads/?$       $scheme://$http_host/wallets/                      permanent;
-    rewrite ^/roadmap/?$         $scheme://$http_host/                              permanent;
-    rewrite ^/matrix/?$          https://chat.decred.org/                           permanent;
-    rewrite ^/recruiting/?$      https://docs.decred.org/contributing/overview/     permanent;
-    rewrite ^/support/?$         $scheme://$http_host/community/                 permanent;
-    rewrite ^/matrix-support/?$  https://chat.decred.org/#/room/#support:decred.org permanent;
+    rewrite ^/roadmap/?$         $scheme://$http_host/                                    permanent;
+    rewrite ^/sustainable/?$     $scheme://$http_host/                                    permanent;
+    rewrite ^/adaptable/?$       $scheme://$http_host/                                    permanent;
+    rewrite ^/security/?$        $scheme://$http_host/                                    permanent;
+    rewrite ^/stakepools/?$      $scheme://$http_host/vsp/                                permanent;
+    rewrite ^/downloads/?$       $scheme://$http_host/wallets/                            permanent;
+    rewrite ^/support/?$         $scheme://$http_host/community/                          permanent;
+    rewrite ^/contributors/?$    https://github.com/orgs/decred/people                    permanent;
+    rewrite ^/matrix/?$          https://chat.decred.org/                                 permanent;
+    rewrite ^/matrix-support/?$  https://chat.decred.org/#/room/#support:decred.org       permanent;
+    rewrite ^/recruiting/?$      https://docs.decred.org/contributing/overview/           permanent;
+    rewrite ^/history/?$         https://docs.decred.org/getting-started/project-history/ permanent;
+    rewrite ^/brief/?$           https://docs.decred.org/getting-started/business-brief/  permanent;
 
     # Redirections for translated pages. Should match the list above.
-    rewrite ^/(.*)/stakepools/?$      $scheme://$http_host/$1/vsp/                       permanent;
-    rewrite ^/(.*)/downloads/?$       $scheme://$http_host/$1/wallets/                   permanent;
-    rewrite ^/(.*)/roadmap/?$         $scheme://$http_host/$1/                           permanent;
-    rewrite ^/(.*)/matrix/?$          https://chat.decred.org/                           permanent;
-    rewrite ^/(.*)/recruiting/?$      https://docs.decred.org/contributing/overview/     permanent;
-    rewrite ^/(.*)/support/?$         $scheme://$http_host/$1/community/                 permanent;
-    rewrite ^/(.*)/matrix-support/?$  https://chat.decred.org/#/room/#support:decred.org permanent;
-
+    rewrite ^/(.*)/roadmap/?$         $scheme://$http_host/$1/                                 permanent;
+    rewrite ^/(.*)/sustainable/?$     $scheme://$http_host/$1/                                 permanent;
+    rewrite ^/(.*)/adaptable/?$       $scheme://$http_host/$1/                                 permanent;
+    rewrite ^/(.*)/security/?$        $scheme://$http_host/$1/                                 permanent;
+    rewrite ^/(.*)/stakepools/?$      $scheme://$http_host/$1/vsp/                             permanent;
+    rewrite ^/(.*)/downloads/?$       $scheme://$http_host/$1/wallets/                         permanent;
+    rewrite ^/(.*)/support/?$         $scheme://$http_host/$1/community/                       permanent;
+    rewrite ^/(.*)/contributors/?$    https://github.com/orgs/decred/people                    permanent;
+    rewrite ^/(.*)/matrix/?$          https://chat.decred.org/                                 permanent;
+    rewrite ^/(.*)/matrix-support/?$  https://chat.decred.org/#/room/#support:decred.org       permanent;
+    rewrite ^/(.*)/recruiting/?$      https://docs.decred.org/contributing/overview/           permanent;
+    rewrite ^/(.*)/history/?$         https://docs.decred.org/getting-started/project-history/ permanent;
+    rewrite ^/(.*)/brief/?$           https://docs.decred.org/getting-started/business-brief/  permanent;
 }
-


### PR DESCRIPTION
- `/brief` and `/history` to new pages in dcrdocs.
- `/contributors` to Decred organization on GitHub.
- Removed secure/sustain/adapt pages to homepage.

Closes #1057