### PR TITLE
Prevent page headings from wrapping.

### DIFF
--- a/src/assets/scss/_common.scss
+++ b/src/assets/scss/_common.scss
@@ -135,6 +135,7 @@ $subpage-header-height: 352px;
     }
 
     .subpage-title {
+        width: 100%;
         color: $white;
         font-family: "dcrweb-poppins", "Verdana", sans-serif;;
         font-size: 34px;


### PR DESCRIPTION
Closes #1063 

![Screenshot from 2022-09-06 10-10-16](https://user-images.githubusercontent.com/6762864/188595778-002047ad-f524-424e-bbff-e6ad7ce7d45a.png)
