### PR TITLE
News: Add Decred Journal - September 2022

### DIFF
--- a/src/data/news/decred_journals.yml
+++ b/src/data/news/decred_journals.yml
@@ -1,4 +1,12 @@
 -
+  Title: "Decred Journal, September 2022"
+  Author: "Decred Journal Team"
+  Permalink: "https://www.decredmagazine.com/decred-journal-september-2022/"
+  Params:
+    sortDate: "2022-10-19"
+    icon: "dcrInMedia.svg"
+    externalSource: "https://www.decredmagazine.com/tag/news/"
+-
   Title: "Decred Journal, August 2022"
   Author: "Decred Journal Team"
   Permalink: "https://www.decredmagazine.com/decred-journal-august-2022/"

--- a/src/data/news/software_releases.yml
+++ b/src/data/news/software_releases.yml
@@ -1,3 +1,11 @@
+-
+  Title: "Decred Release v1.7.5"
+  Author: "Alex Yocom-Piatt"
+  Permalink: "https://github.com/decred/decred-binaries/releases/tag/v1.7.5"
+  Params:
+    sortDate: "2022-10-14"
+    icon: "releaseUpdates.svg"
+    externalSource: "github.com"
 - 
   Title: "DCRDEX Release v0.5.4"
   Author: "Jonathan Chappelow"
@@ -28,14 +36,6 @@
   Permalink: "https://github.com/decred/dcrdex/releases/tag/v0.5.0"
   Params:
     sortDate: "2022-08-23"
-    icon: "releaseUpdates.svg"
-    externalSource: "github.com"
--
-  Title: "Decred Release v1.7.5"
-  Author: "Alex Yocom-Piatt"
-  Permalink: "https://github.com/decred/decred-binaries/releases/tag/v1.7.5"
-  Params:
-    sortDate: "2022-10-14"
     icon: "releaseUpdates.svg"
     externalSource: "github.com"
 -
@@ -87,19 +87,19 @@
     icon: "releaseUpdates.svg"
     externalSource: "github.com"
 -
-  Title: "DCRDEX Release v0.4.0"
-  Author: "Jonathan Chappelow"
-  Permalink: "https://github.com/decred/dcrdex/releases/tag/v0.4.0"
-  Params:
-    sortDate: "2022-01-20"
-    icon: "releaseUpdates.svg"
-    externalSource: "github.com"
--
   Title: "Decred Release v1.7.0"
   Author: "Josh Rickmar"
   Permalink: "https://github.com/decred/decred-binaries/releases/tag/v1.7.0"
   Params:
     sortDate: "2022-01-24"
+    icon: "releaseUpdates.svg"
+    externalSource: "github.com"
+-
+  Title: "DCRDEX Release v0.4.0"
+  Author: "Jonathan Chappelow"
+  Permalink: "https://github.com/decred/dcrdex/releases/tag/v0.4.0"
+  Params:
+    sortDate: "2022-01-20"
     icon: "releaseUpdates.svg"
     externalSource: "github.com"
 -


### PR DESCRIPTION
While here, fix sort order for 2 software releases to keep things organized.

Addressing the idea suggested while [making the News page](https://github.com/decred/dcrweb/pull/1084#issuecomment-1259104449), I looked what "relevant news articles for the month" from [September's Media](https://www.decredmagazine.com/decred-journal-september-2022/#media) can be added as part of this monthly routine but I don't see any candidates besides Buck's interview which is already in `coverage.yml`.

"Selecting" DJ and new software releases is trivial, but selecting what to add to [decred.org/news Coverage](https://decred.org/news/#coverage) is a new thing and is something we should do I think. We need a criteria of what fits that page.

I think we should start with something simple even if it's not well formalized, like: "Any coverage in 'big' outlets or any coverage of 'significant' project milestones", where 'big' and 'significant' will be tuned as we go. Using this criteria I am not including any TA, educational content, art, etc.

Maybe we should add monthly video news (like [this for Sep](https://www.youtube.com/watch?v=7IPj3rWmNY8)) at the cost of adding 2 monthly updates each time.