### PR TITLE
News: Add Nov DJ, 5 releases, 5 coverage items

### DIFF
--- a/src/data/news/coverage.yml
+++ b/src/data/news/coverage.yml
@@ -1,4 +1,49 @@
 -
+  Title: "Decred launches new social media platform Bison Relay"
+  Author: "Benson Toti"
+  Permalink: "https://invezz.com/news/2022/12/16/decred-launches-new-social-media-platform-bison-relay/"
+  Params:
+    sortDate: "2022-12-16"
+    icon: "dcrInMedia.svg"
+    outlet: "Invezz"
+    externalSource: "invezz.com"
+-
+  Title: "Bison Relay: The Sovereign Internet"
+  Author: "Jake Yocom-Piatt"
+  Permalink: "https://blog.decred.org/2022/12/14/Bison-Relay-The-Sovereign-Internet/"
+  Params:
+    sortDate: "2022-12-14"
+    icon: "announcementsDefault.svg"
+    outlet: "Decred Blog"
+    externalSource: "blog.decred.org"
+-
+  Title: "Trapped in the Web"
+  Author: "Jake Yocom-Piatt"
+  Permalink: "https://blog.decred.org/2022/12/09/Trapped-in-the-Web/"
+  Params:
+    sortDate: "2022-12-09"
+    icon: "announcementsDefault.svg"
+    outlet: "Decred Blog"
+    externalSource: "blog.decred.org"
+-
+  Title: "What is wrong with Decred?"
+  Author: "Jake Yocom-Piatt"
+  Permalink: "https://blog.decred.org/2022/12/02/What-is-wrong-with-Decred/"
+  Params:
+    sortDate: "2022-12-02"
+    icon: "announcementsDefault.svg"
+    outlet: "Decred Blog"
+    externalSource: "blog.decred.org"
+-
+  Title: "Jake Yocom-Piatt, Co-Founder of Decred, on Blockchain Fixing Political Voting, Campaign Spending and Privacy | Cryptonews Podcast 182"
+  Author: "Matt Zahab"
+  Permalink: "https://cryptonews.com/exclusives/jake-yocom-piatt-co-founder-of-decred-on-blockchain-fixing-political-voting-campaign-spending-and-privacy.htm"
+  Params:
+    sortDate: "2022-11-29"
+    icon: "interview.svg"
+    outlet: "Cryptonews Podcast"
+    externalSource: "cryptonews.com"
+-
   Title: "VIDEO: Blockchain and elections | Jake Yocom-Piatt | Invezz"
   Author: "Dan Ashmore"
   Permalink: "https://invezz.com/news/2022/11/11/video-blockchain-and-elections-jake-yocom-piatt/"

--- a/src/data/news/decred_journals.yml
+++ b/src/data/news/decred_journals.yml
@@ -1,4 +1,13 @@
 -
+  Title: "Decred Journal, November 2022"
+  Author: "Decred Journal Team"
+  Permalink: "https://www.decredmagazine.com/decred-journal-november-2022/"
+  Params:
+    sortDate: "2022-12-21"
+    icon: "dcrInMedia.svg"
+    outlet: "Decred Magazine"
+    externalSource: "decredmagazine.com/tag/news"
+-
   Title: "Decred Journal, October 2022"
   Author: "Decred Journal Team"
   Permalink: "https://www.decredmagazine.com/decred-journal-october-2022/"

--- a/src/data/news/software_releases.yml
+++ b/src/data/news/software_releases.yml
@@ -1,3 +1,43 @@
+- 
+  Title: "DCRDEX Release v0.5.8"
+  Author: "Jonathan Chappelow"
+  Permalink: "https://github.com/decred/dcrdex/releases/tag/v0.5.8"
+  Params:
+    sortDate: "2022-12-19 22:24:59"
+    icon: "releaseUpdates.svg"
+    externalSource: "github.com"
+- 
+  Title: "Bison Relay Release v0.1.1"
+  Author: "Alex Yocom-Piatt"
+  Permalink: "https://github.com/companyzero/bisonrelay/releases/tag/v0.1.1"
+  Params:
+    sortDate: "2022-12-16 21:19:02"
+    icon: "releaseUpdates.svg"
+    externalSource: "github.com"
+- 
+  Title: "Bison Relay Release v0.1.0"
+  Author: "Alex Yocom-Piatt"
+  Permalink: "https://github.com/companyzero/bisonrelay/releases/tag/v0.1.0"
+  Params:
+    sortDate: "2022-12-15 18:56:48"
+    icon: "releaseUpdates.svg"
+    externalSource: "github.com"
+- 
+  Title: "DCRDEX Release v0.5.7"
+  Author: "Jonathan Chappelow"
+  Permalink: "https://github.com/decred/dcrdex/releases/tag/v0.5.7"
+  Params:
+    sortDate: "2022-11-29 01:02:15"
+    icon: "releaseUpdates.svg"
+    externalSource: "github.com"
+- 
+  Title: "DCRDEX Release v0.5.6"
+  Author: "Jonathan Chappelow"
+  Permalink: "https://github.com/decred/dcrdex/releases/tag/v0.5.6"
+  Params:
+    sortDate: "2022-11-29 00:59:00"
+    icon: "releaseUpdates.svg"
+    externalSource: "github.com"
 -
   Title: "Decred Release v1.7.6"
   Author: "Alex Yocom-Piatt"


### PR DESCRIPTION
Based on #1102 but I can rebase on current `master` if needed.

Included Bison Relay releases. Even though the repos are in companyzero it is a major product built on Decred, well worth the News.