### PR TITLE
News: Add Jan DJ, 1 sw release, 1 coverage item

### DIFF
--- a/src/data/news/coverage.yml
+++ b/src/data/news/coverage.yml
@@ -1,4 +1,12 @@
 -
+  Title: "Combining proof of work and proof of stake for a decentralized financial system with Decred – SlateCast 49"
+  Permalink: "https://cryptoslate.com/podcasts/combining-proof-of-work-and-proof-of-stake-for-a-decentralized-financial-system-with-decred/"
+  Params:
+    author: "Liam Wright"
+    sortDate: "2023-01-23"
+    icon: "interview.svg"
+    outlet: "SlateCast"
+-
   Title: "Decred 2022 End of Year Summary"
   Permalink: "https://www.decredmagazine.com/decred-2022-end-of-year-summary/"
   Params:
@@ -78,6 +86,14 @@
     sortDate: "2022-10-31"
     icon: "interview.svg"
     outlet: "Digital Cash Network"
+-
+  Title: "OP_PEEL: Unilaterally exitable coin pools"
+  Permalink: "https://matheusd.com/post/op_peel/"
+  Params:
+    author: "Matheus Degiovani"
+    sortDate: "2022-10-27"
+    icon: "generalResearch.svg"
+    outlet: "matheusd.com"
 -
   Title: "Brian ‘Buck’ Stafford of Decred On The Future of Money and Banking"
   Permalink: "https://medium.com/authority-magazine/brian-buck-stafford-of-decred-on-the-future-of-money-and-banking-45f25305b409"

--- a/src/data/news/decred_journals.yml
+++ b/src/data/news/decred_journals.yml
@@ -1,4 +1,12 @@
 -
+  Title: "Decred Journal, January 2023"
+  Permalink: "https://www.decredmagazine.com/decred-journal-january-2023/"
+  Params:
+    author: "Decred Journal Team"
+    sortDate: "2023-02-22"
+    icon: "dcrInMedia.svg"
+    outlet: "Decred Magazine"
+-
   Title: "Decred Journal, December 2022"
   Permalink: "https://www.decredmagazine.com/decred-journal-december-2022/"
   Params:

--- a/src/data/news/software_releases.yml
+++ b/src/data/news/software_releases.yml
@@ -1,4 +1,10 @@
 - 
+  Title: "Bison Relay Release v0.1.4"
+  Permalink: "https://github.com/companyzero/bisonrelay/releases/tag/v0.1.4"
+  Params:
+    sortDate: "2023-02-20 19:03:36"
+    icon: "releaseUpdates.svg"
+- 
   Title: "Bison Relay Release v0.1.3"
   Permalink: "https://github.com/companyzero/bisonrelay/releases/tag/v0.1.3"
   Params:


### PR DESCRIPTION
**Based on #1109**

Not including [DCRDEX v0.5.9](https://github.com/decred/dcrdex/releases/tag/v0.5.9) just yet. It is very new and still has placeholders on the release page.