### PR TITLE
news: Add 10 items

### DIFF
--- a/src/data/news/coverage.yml
+++ b/src/data/news/coverage.yml
@@ -15,7 +15,7 @@
     icon: "broadcasts.svg"
     outlet: "Decred YouTube"
 -
-  Title: "The Future Is Now: Jake Yocom-Piatt Of Decred.org On How Their Technological Innovation Will Shake Up The Tech Scene"
+  Title: "The Future Is Now: Jake Yocom-Piatt Of decred.org On How Their Technological Innovation Will Shake Up The Tech Scene"
   Permalink: "https://medium.com/authority-magazine/the-future-is-now-jake-yocom-piatt-on-how-their-technological-innovation-will-shake-u-3966dc1adc22"
   Params:
     author: "Authority Magazine Editorial Staff"
@@ -44,7 +44,7 @@
   Params:
     author: "Patrick Hynds, Ciprian Jichici"
     sortDate: "2023-04-04"
-    icon: "dcrInMedia.svg"
+    icon: "interview.svg"
     outlet: "Entangled Things Podcast"
 -
   Title: "State of the Market - Content and development proposals for Decred feat. Cointelegraph"

--- a/src/data/news/coverage.yml
+++ b/src/data/news/coverage.yml
@@ -1,4 +1,28 @@
 -
+  Title: "Decred v1.8.0 - 'The Forkening' feat. Lead Dev Dave Collins"
+  Permalink: "https://www.youtube.com/watch?v=TJnP_t4dEq8"
+  Params:
+    author: "Phoenix Green, Exitus"
+    sortDate: "2023-08-06"
+    icon: "broadcasts.svg"
+    outlet: "Decred YouTube"
+-
+  Title: "Crypto Integrations - Cake Wallet"
+  Permalink: "https://www.youtube.com/watch?v=0KKsD4ZhZn0"
+  Params:
+    author: "Phoenix Green, Tivra"
+    sortDate: "2023-08-02"
+    icon: "broadcasts.svg"
+    outlet: "Decred YouTube"
+-
+  Title: "The Future Is Now: Jake Yocom-Piatt Of Decred.org On How Their Technological Innovation Will Shake Up The Tech Scene"
+  Permalink: "https://medium.com/authority-magazine/the-future-is-now-jake-yocom-piatt-on-how-their-technological-innovation-will-shake-u-3966dc1adc22"
+  Params:
+    author: "Authority Magazine Editorial Staff"
+    sortDate: "2023-05-21"
+    icon: "dcrInMedia.svg"
+    outlet: "Authority Magazine"
+-
   Title: "Decred announces DCRDEX 0.6 with support for Ethereum and USDC swaps"
   Permalink: "https://invezz.com/news/2023/04/17/decred-announces-dcrdex-0-6-with-support-for-ethereum-and-usdc-swaps/"
   Params:
@@ -14,6 +38,14 @@
     sortDate: "2023-04-05"
     icon: "interview.svg"
     outlet: "Decred YouTube"
+-
+  Title: "Quantum and Cryptocurrency with Jake Yocom-Piatt"
+  Permalink: "https://www.entangledthings.com/all-episodes/episode/7bef6428/quantum-and-cryptocurrency-with-jake-yocom-piatt"
+  Params:
+    author: "Patrick Hynds, Ciprian Jichici"
+    sortDate: "2023-04-04"
+    icon: "dcrInMedia.svg"
+    outlet: "Entangled Things Podcast"
 -
   Title: "State of the Market - Content and development proposals for Decred feat. Cointelegraph"
   Permalink: "https://www.youtube.com/watch?v=d-tCKPYOII0"
@@ -40,12 +72,12 @@
     outlet: "SlateCast"
 -
   Title: "Decred 2022 End of Year Summary"
-  Permalink: "https://www.decredmagazine.com/decred-2022-end-of-year-summary/"
+  Permalink: "https://www.cypherpunktimes.com/decred-2022-end-of-year-summary/"
   Params:
     author: "Phoenix Green"
     sortDate: "2022-12-31"
     icon: "dcrInMedia.svg"
-    outlet: "Decred Magazine"
+    outlet: "Cypherpunk Times"
 -
   Title: "My Chat with Decred Founder/CEO Jake Yocom-Piatt"
   Permalink: "https://www.youtube.com/watch?v=OS_AOyMdAeU"

--- a/src/data/news/decred_journals.yml
+++ b/src/data/news/decred_journals.yml
@@ -3,7 +3,7 @@
   Permalink: "https://www.cypherpunktimes.com/decred-journal-july-2023/"
   Params:
     author: "Decred Journal Team"
-    sortDate: "2023-07-22"
+    sortDate: "2023-08-22"
     icon: "dcrInMedia.svg"
     outlet: "Cypherpunk Times"
 -

--- a/src/data/news/decred_journals.yml
+++ b/src/data/news/decred_journals.yml
@@ -1,75 +1,107 @@
 -
+  Title: "Decred Journal, July 2023"
+  Permalink: "https://www.cypherpunktimes.com/decred-journal-july-2023/"
+  Params:
+    author: "Decred Journal Team"
+    sortDate: "2023-07-22"
+    icon: "dcrInMedia.svg"
+    outlet: "Cypherpunk Times"
+-
+  Title: "Decred Journal, June 2023"
+  Permalink: "https://www.cypherpunktimes.com/decred-journal-june-2023/"
+  Params:
+    author: "Decred Journal Team"
+    sortDate: "2023-07-22"
+    icon: "dcrInMedia.svg"
+    outlet: "Cypherpunk Times"
+-
+  Title: "Decred Journal, May 2023"
+  Permalink: "https://www.cypherpunktimes.com/decred-journal-may-2023/"
+  Params:
+    author: "Decred Journal Team"
+    sortDate: "2023-06-22"
+    icon: "dcrInMedia.svg"
+    outlet: "Cypherpunk Times"
+-
+  Title: "Decred Journal, April 2023"
+  Permalink: "https://www.cypherpunktimes.com/decred-journal-april-2023/"
+  Params:
+    author: "Decred Journal Team"
+    sortDate: "2023-05-21"
+    icon: "dcrInMedia.svg"
+    outlet: "Cypherpunk Times"
+-
   Title: "Decred Journal, March 2023"
-  Permalink: "https://www.decredmagazine.com/decred-journal-march-2023/"
+  Permalink: "https://www.cypherpunktimes.com/decred-journal-march-2023/"
   Params:
     author: "Decred Journal Team"
     sortDate: "2023-04-22"
     icon: "dcrInMedia.svg"
-    outlet: "Decred Magazine"
+    outlet: "Cypherpunk Times"
 -
   Title: "Decred Journal, February 2023"
-  Permalink: "https://www.decredmagazine.com/decred-journal-february-2023/"
+  Permalink: "https://www.cypherpunktimes.com/decred-journal-february-2023/"
   Params:
     author: "Decred Journal Team"
     sortDate: "2023-03-23"
     icon: "dcrInMedia.svg"
-    outlet: "Decred Magazine"
+    outlet: "Cypherpunk Times"
 -
   Title: "Decred Journal, January 2023"
-  Permalink: "https://www.decredmagazine.com/decred-journal-january-2023/"
+  Permalink: "https://www.cypherpunktimes.com/decred-journal-january-2023/"
   Params:
     author: "Decred Journal Team"
     sortDate: "2023-02-22"
     icon: "dcrInMedia.svg"
-    outlet: "Decred Magazine"
+    outlet: "Cypherpunk Times"
 -
   Title: "Decred Journal, December 2022"
-  Permalink: "https://www.decredmagazine.com/decred-journal-december-2022/"
+  Permalink: "https://www.cypherpunktimes.com/decred-journal-december-2022/"
   Params:
     author: "Decred Journal Team"
     sortDate: "2023-01-21"
     icon: "dcrInMedia.svg"
-    outlet: "Decred Magazine"
+    outlet: "Cypherpunk Times"
 -
   Title: "Decred Journal, November 2022"
-  Permalink: "https://www.decredmagazine.com/decred-journal-november-2022/"
+  Permalink: "https://www.cypherpunktimes.com/decred-journal-november-2022/"
   Params:
     author: "Decred Journal Team"
     sortDate: "2022-12-21"
     icon: "dcrInMedia.svg"
-    outlet: "Decred Magazine"
+    outlet: "Cypherpunk Times"
 -
   Title: "Decred Journal, October 2022"
-  Permalink: "https://www.decredmagazine.com/decred-journal-october-2022/"
+  Permalink: "https://www.cypherpunktimes.com/decred-journal-october-2022/"
   Params:
     author: "Decred Journal Team"
     sortDate: "2022-11-19"
     icon: "dcrInMedia.svg"
-    outlet: "Decred Magazine"
+    outlet: "Cypherpunk Times"
 -
   Title: "Decred Journal, September 2022"
-  Permalink: "https://www.decredmagazine.com/decred-journal-september-2022/"
+  Permalink: "https://www.cypherpunktimes.com/decred-journal-september-2022/"
   Params:
     author: "Decred Journal Team"
     sortDate: "2022-10-19"
     icon: "dcrInMedia.svg"
-    outlet: "Decred Magazine"
+    outlet: "Cypherpunk Times"
 -
   Title: "Decred Journal, August 2022"
-  Permalink: "https://www.decredmagazine.com/decred-journal-august-2022/"
+  Permalink: "https://www.cypherpunktimes.com/decred-journal-august-2022/"
   Params:
     author: "Decred Journal Team"
     sortDate: "2022-09-16"
     icon: "dcrInMedia.svg"
-    outlet: "Decred Magazine"
+    outlet: "Cypherpunk Times"
 -
   Title: "Decred Journal, July 2022"
-  Permalink: "https://www.decredmagazine.com/decred-journal-july-2022/"
+  Permalink: "https://www.cypherpunktimes.com/decred-journal-july-2022/"
   Params:
     author: "Decred Journal Team"
     sortDate: "2022-08-17"
     icon: "dcrInMedia.svg"
-    outlet: "Decred Magazine"
+    outlet: "Cypherpunk Times"
 -
   Title: "Decred Journal, June 2022"
   Permalink: "https://medium.com/decred/decred-journal-june-2022-306ca1c67685"

--- a/src/data/news/software_releases.yml
+++ b/src/data/news/software_releases.yml
@@ -1,3 +1,9 @@
+- 
+  software: bison
+  version: 0.1.8
+  Permalink: "https://github.com/companyzero/bisonrelay/releases/tag/v0.1.8"
+  Params:
+    sortDate: "2023-08-21 20:26:50"
 -
   software: decred
   version: 1.8.0
@@ -16,6 +22,12 @@
   Permalink: "https://github.com/decred/dcrdex/releases/tag/v0.6.1"
   Params:
     sortDate: "2023-05-05 04:29:48"
+- 
+  software: bison
+  version: 0.1.7
+  Permalink: "https://github.com/companyzero/bisonrelay/releases/tag/v0.1.7"
+  Params:
+    sortDate: "2023-04-25 18:05:36"
 -
   software: decred
   version: 1.7.7


### PR DESCRIPTION
- Add 2 Bison Relay non-RC releases
- Add 4 Decred Journal issues
- Add 4 Coverage items
  - Selection criteria used is "anything notable, ideally involving people/orgs external to Decred"
- Fix dead decredmagazine.com links to cypherpunktimes.com
  - Not expecting the redirects will be fixed anytime soon

I still don't have a good rule to follow for choosing which `icon` to use. If anyone has one, please open an issue, tag me and I will apply it to make our news icons consistent.