### PR TITLE
Update for dex 0.6.3

### DIFF
--- a/src/assets/scss/_wallets.scss
+++ b/src/assets/scss/_wallets.scss
@@ -59,10 +59,13 @@
                 margin-bottom: 7px;
                 margin-right: 3px;
                 
-                a,
-                a:hover {
+                a {
                     color: $white;
                     opacity: 0.89;
+                }
+                
+                a:hover {
+                    opacity: 1.0;
                 }
 
                 &.direct-dl {

--- a/src/data/news/software_releases.yml
+++ b/src/data/news/software_releases.yml
@@ -1,4 +1,10 @@
 - 
+  software: dcrdex
+  version: 0.6.3
+  Permalink: "https://github.com/decred/dcrdex/releases/tag/v0.6.3"
+  Params:
+    sortDate: "2023-09-08 04:29:48"
+-
   software: bison
   version: 0.1.8
   Permalink: "https://github.com/companyzero/bisonrelay/releases/tag/v0.1.8"

--- a/src/data/wallets/wallets.yml
+++ b/src/data/wallets/wallets.yml
@@ -36,11 +36,12 @@
     - core_software
   highlight: true
   links:
-    - title: GitHub
-      url: https://github.com/decred/dcrdex/releases/tag/v0.6.1
+    - title: Download
+      url: https://github.com/decred/dcrdex/releases/tag/v0.6.3
     - title: Release notes
-      url: https://github.com/decred/dcrdex/blob/master/docs/release-notes/release-notes-0.6.1.md
-
+      url: https://github.com/decred/dcrdex/blob/master/docs/release-notes/release-notes-0.6.0.md
+    - title: Website
+      url: https://dex.decred.org
 - id: commandline
   name: Command-line app suite
   tags:


### PR DESCRIPTION
- Change download link to read "Download" instead of "GitHub"
- Add news item
- Update download link to 0.6.3
- Revert release note link to 0.6.0. This is a more far more detailed document than the patch release note (which links back to the 0.6.0 note anyway)
- Add link to dex.decred.org

And 

- Change color slightly so its easier to see which link you are hovering
over.

Closes #1141