### PR TITLE
exchanges: Remove Changelly

### DIFF
--- a/src/data/exchanges/exchanges.yml
+++ b/src/data/exchanges/exchanges.yml
@@ -46,11 +46,6 @@
   name: OKX
   highlight: false
 -
-  url: "https://changelly.com/"
-  tags:
-  name: Changelly
-  highlight: false
--
   url: "https://www.bitladon.com/"
   tags:
     - fiat


### PR DESCRIPTION
Changelly.com no longer has DCR since 2023-09-19 or earlier.

On 2023-10-19 their support team replied that DCR was temporarily switched off but as of this commit DCR is still missing from the dropdown at changelly.com and also from their new System Health dashboard (https://pro.changelly.com/system-monitor).

Removing for now, we can add it back if they enable DCR again.