### PR TITLE
wallets: Fix Cryptopower link

### DIFF
--- a/src/data/wallets/wallets.yml
+++ b/src/data/wallets/wallets.yml
@@ -48,7 +48,7 @@
   highlight: true
   links:
     - title: Download and release notes
-      url: https://github.com/crypto-power/cryptopower/releases/tag/release-v1.0.0
+      url: https://github.com/crypto-power/cryptopower/releases/tag/v1.0.0
     - title: Website
       url: https://cryptopower.dev
 


### PR DESCRIPTION
The link currently deployed at https://decred.org/wallets/ is broken. Let's fix it quickly without changing anything else.