### PR TITLE
software: Add 2 BR releases, re-add decred 1.8.1.

### DIFF
--- a/src/data/news/software_releases.yml
+++ b/src/data/news/software_releases.yml
@@ -6,6 +6,24 @@
     sortDate: "2024-05-21 10:29:00"
 -
   software: bison
+  version: 0.2.0
+  Permalink: "https://github.com/companyzero/bisonrelay/releases/tag/v0.2.0"
+  Params:
+    sortDate: "2024-05-10 18:48:00"
+-
+  software: bison
+  version: 0.1.10
+  Permalink: "https://github.com/companyzero/bisonrelay/releases/tag/v0.1.10"
+  Params:
+    sortDate: "2024-01-17 19:36:48"
+-
+  software: decred
+  version: 1.8.1
+  Permalink: "https://github.com/decred/decred-binaries/releases/tag/v1.8.1"
+  Params:
+    sortDate: "2023-10-09 16:00:22"
+-
+  software: bison
   version: 0.1.9
   Permalink: "https://github.com/companyzero/bisonrelay/releases/tag/v0.1.9"
   Params:


### PR DESCRIPTION
1.8.1 was mistakenly removed in the recent update to add 2.0.0.