### PR TITLE
exchanges: Remove bitladon.

### DIFF
--- a/src/data/exchanges/exchanges.yml
+++ b/src/data/exchanges/exchanges.yml
@@ -47,12 +47,6 @@
   name: OKX
   highlight: false
 -
-  url: "https://www.bitladon.com/"
-  tags:
-    - fiat
-  name: Bitladon
-  highlight: false
--
   url: "https://bitvavo.com/"
   tags:
     - fiat


### PR DESCRIPTION
Bitladon was bought by Kraken and no longer runs as an independent site.