### PR TITLE
Remove bitvavo from exchanges.

### DIFF
--- a/src/data/exchanges/exchanges.yml
+++ b/src/data/exchanges/exchanges.yml
@@ -31,12 +31,6 @@
   name: Swyftx
   highlight: false
 -
-  url: "https://bitvavo.com/"
-  tags:
-    - "fiat"
-  name: Bitvavo
-  highlight: false
--
   url: "https://www.gate.io/"
   tags:
   name: "Gate.io"


### PR DESCRIPTION
Community member franzl reported bitvavo is "Trade only" meaning that DCR can not be withdrawn from their platform. IMO this warrants removal from https://decred.org/exchanges/

Tagging @jzbz @exitus1 as the most involved in exchange relationships (afaik)